### PR TITLE
Fix typo in Contact Us test selector (#203)

### DIFF
--- a/tests/atk_contact_us/atk_contact_us.spec.js
+++ b/tests/atk_contact_us/atk_contact_us.spec.js
@@ -77,7 +77,7 @@ test.describe('Contact Us tests.', () => {
     // Begin Contact us.
     const user = atkUtilities.createRandomUser()
     await page.goto('/')
-    await page.getByRole('link', { name: 'COTACT US' }).first().click()
+    await page.getByRole('link', { name: 'CONTACT US' }).first().click()
 
     await page.getByLabel('Your name').fill(user.userName)
     await page.getByLabel('Your email').fill(user.userEmail)


### PR DESCRIPTION
## Summary

Fixed a typo in the Contact Us test selector that was preventing the test from finding the "CONTACT US" link.

### Root Cause
The test selector on line 80 used `'COTACT US'` instead of `'CONTACT US'` (missing the letter 'N').

### Classification
**TEST ISSUE** - The selector had a typo preventing it from matching the actual "CONTACT US" link on the website.

### Changes Made
- Changed `'COTACT US'` to `'CONTACT US'` in `tests/atk_contact_us/atk_contact_us.spec.js:80`

### Verification
Test passed on retry after the fix was applied.

Fixes #203

---
Generated with [Claude Code](https://claude.ai/code)