### PR TITLE
feat: add canonical PR reviewer pipeline

### DIFF
--- a/.agents/pr-review.yml
+++ b/.agents/pr-review.yml
@@ -1,0 +1,32 @@
+# .agents/pr-review.yml — PR reviewer config for performantlabs.com
+
+project:
+  name: "performantlabs.com"
+  timezone: "America/Los_Angeles"
+
+pr_agent:
+  enabled: true
+  model: "deepseek/deepseek-v4-pro"
+  skip_docs_only: false
+  status_check: true
+  cancel_in_flight: true
+
+local_review:
+  enabled: true
+  default_model: "claude-sonnet-4-6"
+  shell_alias: ""
+
+dual_review:
+  enabled: false
+
+dco:
+  enabled: true
+
+pr_template:
+  enabled: true
+
+test_tiers:
+  t1_headless: false
+  t2_aria: true
+  t2_5_authenticated: false
+  t3_visual: false

--- a/.agents/scripts/check-pr-review-readiness.sh
+++ b/.agents/scripts/check-pr-review-readiness.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# check-pr-review-readiness.sh — Verify all enabled PR review methods are operational.
+#
+# Reads .agents/pr-review.yml to determine which methods are expected, then
+# checks each one. Always present in the project regardless of config.
+#
+# Usage: .agents/scripts/check-pr-review-readiness.sh
+# Run from the repo root.
+
+set -euo pipefail
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+PASS="✅"; FAIL="❌"; WARN="⚠️ "
+errors=0
+
+# ── Config reader (yq with grep fallback) ──────────────────────────────────
+CONFIG_FILE=".agents/pr-review.yml"
+
+cfg_get() {
+  local key="$1" fallback="${2:-}"
+  if [[ ! -f "$CONFIG_FILE" ]]; then echo "$fallback"; return; fi
+  if command -v yq &>/dev/null; then
+    local val
+    val=$(yq e "${key} // \"\"" "$CONFIG_FILE" 2>/dev/null)
+    echo "${val:-$fallback}"
+  else
+    local stripped="${key##*.}"
+    local val
+    val=$(grep -E "^\s*${stripped}:" "$CONFIG_FILE" 2>/dev/null | head -1 \
+          | sed 's/.*: *//;s/"//g;s/\r//')
+    echo "${val:-$fallback}"
+  fi
+}
+
+PROJECT_NAME="$(cfg_get '.project.name' "$(basename "$PWD")")"
+
+echo ""
+echo "═══════════════════════════════════════════════"
+echo " ${PROJECT_NAME} — PR Review Readiness Check"
+echo "═══════════════════════════════════════════════"
+
+# ── Check: config file itself ────────────────────────────────────────────────
+echo ""
+echo "── Config ──"
+if [[ -f "$CONFIG_FILE" ]]; then
+  echo "${PASS} .agents/pr-review.yml present"
+else
+  echo "${WARN} .agents/pr-review.yml missing — run setup-pr-review.sh to create it"
+  echo "     (continuing with defaults: assuming all methods enabled)"
+fi
+
+PR_AGENT_ENABLED="$(cfg_get '.pr_agent.enabled' 'false')"
+LOCAL_ENABLED="$(cfg_get '.local_review.enabled' 'false')"
+DUAL_ENABLED="$(cfg_get '.dual_review.enabled' 'false')"
+DCO_ENABLED="$(cfg_get '.dco.enabled' 'false')"
+SHELL_ALIAS="$(cfg_get '.local_review.shell_alias' '')"
+
+# ── Method 1: PR-Agent (cloud, GitHub Actions) ────────────────────────────────
+if [[ "$PR_AGENT_ENABLED" == "true" ]]; then
+  echo ""
+  echo "── Method 1: PR-Agent CI (GitHub Actions) ──"
+
+  if [[ -f ".pr_agent.toml" ]]; then
+    echo "${PASS} .pr_agent.toml present"
+  else
+    echo "${FAIL} .pr_agent.toml missing — copy from ai_guidance/pipelines/pr-reviewer/templates/"
+    ((errors++))
+  fi
+
+  if [[ -f ".github/workflows/pr-review.yml" ]]; then
+    echo "${PASS} .github/workflows/pr-review.yml present"
+  else
+    echo "${FAIL} .github/workflows/pr-review.yml missing — copy from ai_guidance/pipelines/pr-reviewer/templates/"
+    ((errors++))
+  fi
+
+  echo "${WARN} DEEPSEEK_API_KEY — cannot verify GitHub secrets locally."
+  echo "     Confirm it is set: GitHub → repo → Settings → Secrets → Actions"
+else
+  echo ""
+  echo "── Method 1: PR-Agent CI ── DISABLED (pr_agent.enabled: false)"
+fi
+
+# ── Method 2: Local review (claude -p) ─────────────────────────────────────
+if [[ "$LOCAL_ENABLED" == "true" ]]; then
+  echo ""
+  echo "── Method 2: Local review (claude -p) ──"
+
+  if [[ -x ".agents/scripts/pr-review.sh" ]]; then
+    echo "${PASS} .agents/scripts/pr-review.sh present and executable"
+  elif [[ -f ".agents/scripts/pr-review.sh" ]]; then
+    echo "${FAIL} .agents/scripts/pr-review.sh exists but is not executable (run: chmod +x .agents/scripts/pr-review.sh)"
+    ((errors++))
+  else
+    echo "${FAIL} .agents/scripts/pr-review.sh missing — copy from ai_guidance/pipelines/pr-reviewer/scripts/"
+    ((errors++))
+  fi
+
+  if command -v claude &>/dev/null; then
+    echo "${PASS} claude CLI found: $(command -v claude)"
+    if claude auth status &>/dev/null 2>&1; then
+      echo "${PASS} claude is authenticated"
+    else
+      echo "${WARN} claude may not be authenticated — run: claude auth login"
+    fi
+  else
+    echo "${FAIL} claude CLI not found — install Claude Code"
+    ((errors++))
+  fi
+
+  if command -v gh &>/dev/null; then
+    echo "${PASS} gh CLI found: $(command -v gh)"
+    if gh auth status &>/dev/null 2>&1; then
+      echo "${PASS} gh is authenticated"
+    else
+      echo "${WARN} gh not authenticated — run: gh auth login"
+    fi
+  else
+    echo "${FAIL} gh CLI not found — install: brew install gh"
+    ((errors++))
+  fi
+
+  if [[ -n "$SHELL_ALIAS" ]]; then
+    if [[ -f ".agents/scripts/shell-aliases.sh" ]]; then
+      echo "${PASS} shell-aliases.sh present (alias: ${SHELL_ALIAS})"
+      echo "     Source it from ~/.zshrc if you haven't already."
+    else
+      echo "${WARN} shell-aliases.sh missing — alias '${SHELL_ALIAS}' not available"
+      echo "     Copy from ai_guidance/pipelines/pr-reviewer/scripts/"
+    fi
+  fi
+else
+  echo ""
+  echo "── Method 2: Local review ── DISABLED (local_review.enabled: false)"
+fi
+
+# ── Method 3: O3 dual-review ────────────────────────────────────────────────
+if [[ "$DUAL_ENABLED" == "true" ]]; then
+  echo ""
+  echo "── Method 3: O3 dual-review ──"
+
+  if [[ -x ".agents/scripts/dual-review.sh" ]]; then
+    echo "${PASS} .agents/scripts/dual-review.sh present and executable"
+  elif [[ -f ".agents/scripts/dual-review.sh" ]]; then
+    echo "${FAIL} .agents/scripts/dual-review.sh exists but is not executable"
+    ((errors++))
+  else
+    echo "${FAIL} .agents/scripts/dual-review.sh missing — copy from ai_guidance/pipelines/pr-reviewer/scripts/"
+    ((errors++))
+  fi
+
+  # Source .env to check for key
+  # shellcheck disable=SC1091
+  [[ -f ".env" ]] && set -a && source .env && set +a 2>/dev/null || true
+
+  if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+    echo "${PASS} OPENAI_API_KEY found in environment"
+  else
+    echo "${FAIL} OPENAI_API_KEY not set — dual-review.sh will fail"
+    echo "     Add it to your .env or shell profile."
+    ((errors++))
+  fi
+
+  if ! command -v jq &>/dev/null; then
+    echo "${FAIL} jq not found — required for dual-review.sh (brew install jq)"
+    ((errors++))
+  else
+    echo "${PASS} jq found: $(command -v jq)"
+  fi
+else
+  echo ""
+  echo "── Method 3: O3 dual-review ── DISABLED (dual_review.enabled: false)"
+fi
+
+# ── DCO workflow ─────────────────────────────────────────────────────────────
+if [[ "$DCO_ENABLED" == "true" ]]; then
+  echo ""
+  echo "── DCO enforcement ──"
+  if [[ -f ".github/workflows/dco.yml" ]]; then
+    echo "${PASS} .github/workflows/dco.yml present"
+  else
+    echo "${FAIL} .github/workflows/dco.yml missing — copy from ai_guidance/pipelines/pr-reviewer/templates/"
+    ((errors++))
+  fi
+fi
+
+# ── Manual test hint ──────────────────────────────────────────────────────────
+if [[ "$LOCAL_ENABLED" == "true" ]]; then
+  echo ""
+  echo "── Manual local test ──"
+  echo "   .agents/scripts/pr-review.sh <PR-number>"
+  echo "   .agents/scripts/pr-review.sh <PR-number> --post"
+  if [[ -n "$SHELL_ALIAS" ]]; then
+    echo "   ${SHELL_ALIAS} <PR-number>   (if shell-aliases.sh is sourced)"
+  fi
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "═══════════════════════════════════════════════"
+if [[ $errors -eq 0 ]]; then
+  echo " ${PASS} All hard checks passed."
+else
+  echo " ${FAIL} ${errors} hard check(s) failed — fix them before opening a PR."
+fi
+echo "═══════════════════════════════════════════════"
+echo ""
+
+exit $errors

--- a/.agents/scripts/dual-review.sh
+++ b/.agents/scripts/dual-review.sh
@@ -97,7 +97,7 @@ fi
 
 # Source .env so keys defined there are available.
 # shellcheck disable=SC1091
-[[ -f ".env" ]] && set -a && source .env && set +a
+if [[ -f ".env" ]]; then set -a; source .env || true; set +a; fi
 
 if [[ -z "${OPENAI_API_KEY:-}" ]]; then
   echo "Error: OPENAI_API_KEY is not set" >&2; exit 1

--- a/.agents/scripts/dual-review.sh
+++ b/.agents/scripts/dual-review.sh
@@ -1,0 +1,328 @@
+#!/usr/bin/env bash
+# dual-review.sh — Independent architecture review via the OpenAI Responses API.
+#
+# Used by the Orchestrator at Phase 4 (brief review) and Phase 7 (impl review)
+# of the implementstory workflow. Activated only when dual_review.enabled is true
+# in .agents/pr-review.yml (or DUAL_REVIEW=1 env override).
+#
+# Usage:
+#   .agents/scripts/dual-review.sh --mode brief --task-id <id> [--round 2]
+#   .agents/scripts/dual-review.sh --mode impl  --task-id <id> [--round 2]
+#
+# Output written to:
+#   .argos/stories/<taskId>/dual-{brief|impl}-review[-2].md
+# and echoed to stdout.
+#
+# Discussion protocol (enforced by Orchestrator):
+#   Round 1: reviewer raises findings → Orchestrator writes argos-{brief|impl}-response.md
+#   Round 2: reviewer re-evaluates → ACCEPT or MAINTAIN BLOCK per finding
+#   Still BLOCK after round 2 → escalate to human
+#
+# Gate behaviour (enforced by Orchestrator):
+#   BLOCK findings → hard gate; story pauses until resolved.
+#   WARN / NIT     → recorded, not blocking.
+#
+# Prerequisites:
+#   - OPENAI_API_KEY set in .env or environment
+#   - curl and jq available
+#   - Run from the repo root (CLAUDE.md must be in cwd)
+
+set -euo pipefail
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+# ── Config reader (yq with grep fallback) ──────────────────────────────────
+CONFIG_FILE=".agents/pr-review.yml"
+
+cfg_get() {
+  local key="$1" fallback="${2:-}"
+  if [[ ! -f "$CONFIG_FILE" ]]; then echo "$fallback"; return; fi
+  if command -v yq &>/dev/null; then
+    local val
+    val=$(yq e "${key} // \"\"" "$CONFIG_FILE" 2>/dev/null)
+    echo "${val:-$fallback}"
+  else
+    local stripped="${key##*.}"
+    local val
+    val=$(grep -E "^\s*${stripped}:" "$CONFIG_FILE" 2>/dev/null | head -1 \
+          | sed 's/.*: *//;s/"//g;s/\r//')
+    echo "${val:-$fallback}"
+  fi
+}
+
+# ── Global switch ────────────────────────────────────────────────────────────
+# DUAL_REVIEW=1 env var overrides the config file (useful for one-off runs).
+if [[ "${DUAL_REVIEW:-0}" != "1" ]]; then
+  ENABLED="$(cfg_get '.dual_review.enabled' 'false')"
+  if [[ "$ENABLED" != "true" ]]; then
+    echo "# Dual Review — SKIPPED (dual_review.enabled is false; set DUAL_REVIEW=1 to force)" >&2
+    exit 0
+  fi
+fi
+
+# ── Argument parsing ─────────────────────────────────────────────────────────
+MODE=""
+TASK_ID=""
+ROUND=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)    MODE="${2:?--mode requires a value}";    shift 2 ;;
+    --task-id) TASK_ID="${2:?--task-id requires a value}"; shift 2 ;;
+    --round)   ROUND="${2:-1}";  shift 2 ;;
+    *) echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$MODE" || -z "$TASK_ID" ]]; then
+  echo "Usage: $0 --mode <brief|impl> --task-id <id> [--round <1|2>]" >&2
+  exit 1
+fi
+
+if [[ "$MODE" != "brief" && "$MODE" != "impl" ]]; then
+  echo "Error: --mode must be 'brief' or 'impl'" >&2
+  exit 1
+fi
+
+# ── Preflight checks ─────────────────────────────────────────────────────────
+if ! command -v jq &>/dev/null; then
+  echo "Error: jq is required (brew install jq)" >&2; exit 1
+fi
+if ! command -v curl &>/dev/null; then
+  echo "Error: curl is required" >&2; exit 1
+fi
+if [[ ! -f "CLAUDE.md" ]]; then
+  echo "Error: run from the repo root (CLAUDE.md not found)" >&2; exit 1
+fi
+
+# Source .env so keys defined there are available.
+# shellcheck disable=SC1091
+[[ -f ".env" ]] && set -a && source .env && set +a
+
+if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+  echo "Error: OPENAI_API_KEY is not set" >&2; exit 1
+fi
+
+# ── Paths ─────────────────────────────────────────────────────────────────────
+PROJECT_NAME="$(cfg_get '.project.name' "$(basename "$PWD")")"
+MODEL="${DUAL_REVIEW_MODEL:-$(cfg_get '.dual_review.model' 'o3')}"
+
+# Support .argos/stories/<taskId>/ and legacy .argos/<taskId>/ layouts.
+if [[ -d ".argos/stories/${TASK_ID}" ]]; then
+  ARGOS_DIR=".argos/stories/${TASK_ID}"
+elif [[ -d ".argos/${TASK_ID}" ]]; then
+  ARGOS_DIR=".argos/${TASK_ID}"
+else
+  ARGOS_DIR=".argos/stories/${TASK_ID}"
+fi
+mkdir -p "$ARGOS_DIR"
+
+BRIEF_FILE="${ARGOS_DIR}/brief.md"
+HANDOFF_FILE="${ARGOS_DIR}/feature-handoff.md"
+ARGOS_BRIEF_RESPONSE="${ARGOS_DIR}/argos-brief-response.md"
+ARGOS_IMPL_RESPONSE="${ARGOS_DIR}/argos-impl-response.md"
+
+if [[ "$MODE" == "brief" ]]; then
+  [[ "$ROUND" == "2" ]] \
+    && OUTPUT_FILE="${ARGOS_DIR}/dual-brief-review-2.md" \
+    || OUTPUT_FILE="${ARGOS_DIR}/dual-brief-review.md"
+else
+  [[ "$ROUND" == "2" ]] \
+    && OUTPUT_FILE="${ARGOS_DIR}/dual-impl-review-2.md" \
+    || OUTPUT_FILE="${ARGOS_DIR}/dual-impl-review.md"
+fi
+
+# ── Build reviewer prompt (safe construction) ─────────────────────────────────
+# Static sections use quoted heredocs (<<'EOF') — no variable or command
+# expansion. Controlled values (PROJECT_NAME, TASK_ID) are inserted with
+# printf. Untrusted file contents (brief, handoff, diff) are appended with
+# `cat file >> tmp` — never expanded inside a double-quoted string.
+
+PROMPT_TMP=$(mktemp /tmp/dual-review-prompt.XXXXXX)
+PAYLOAD_TMP=$(mktemp /tmp/dual-review-payload.XXXXXX)
+trap 'rm -f "$PROMPT_TMP" "$PAYLOAD_TMP"' EXIT
+
+if [[ "$MODE" == "brief" && "$ROUND" == "1" ]]; then
+  [[ -f "$BRIEF_FILE" ]] || { echo "Error: brief not found at ${BRIEF_FILE}" >&2; exit 1; }
+
+  printf 'You are an independent architecture reviewer for the %s project. You have no loyalty to the brief'\''s framing — your job is to find problems before they are built.\n\n' \
+    "$PROJECT_NAME" >> "$PROMPT_TMP"
+  cat >> "$PROMPT_TMP" <<'STATIC'
+Your discipline:
+- Any claim about runtime behaviour — execution ordering, library defaults, middleware sequencing, plugin lifecycle, external state — is a hypothesis until verified from source (library code or official docs). Treat unverified runtime claims as BLOCK findings.
+- Be adversarial to the framing you are given. Your job is to find problems, not validate decisions.
+
+Also check:
+- Acceptance criteria are complete and testable.
+- Scope is appropriately bounded.
+- Missing error paths or edge cases.
+
+Output format (use exactly this structure):
+STATIC
+  printf '\n## Brief Review — %s (Round 1)\n' "$TASK_ID" >> "$PROMPT_TMP"
+  cat >> "$PROMPT_TMP" <<'STATIC'
+
+### BLOCK findings
+Each as: **[B-N]** description — why it blocks — what must be clarified or fixed.
+If none: "None."
+
+### WARN findings
+Each as: **[W-N]** description — recommendation.
+If none: "None."
+
+### NIT findings
+Each as: **[NIT-N]** description.
+If none: "None."
+
+### Verdict
+PASS — no BLOCK findings; implementation may proceed.
+OR
+BLOCK — N blocking finding(s); must resolve before implementation starts.
+
+---
+
+## Task Brief
+
+STATIC
+  cat "$BRIEF_FILE" >> "$PROMPT_TMP"
+
+elif [[ "$MODE" == "brief" && "$ROUND" == "2" ]]; then
+  [[ -f "$ARGOS_BRIEF_RESPONSE" ]] || { echo "Error: round 2 requires ${ARGOS_BRIEF_RESPONSE}" >&2; exit 1; }
+
+  printf 'You are an independent architecture reviewer for the %s project. This is Round 2 — you previously raised BLOCK findings on the task brief, and the Orchestrator has responded. Evaluate each response.\n' \
+    "$PROJECT_NAME" >> "$PROMPT_TMP"
+  printf '\n## Brief Review — %s (Round 2)\n' "$TASK_ID" >> "$PROMPT_TMP"
+  cat >> "$PROMPT_TMP" <<'STATIC'
+
+### BLOCK finding responses
+For each: **[B-N] ACCEPTED** — reason. OR **[B-N] MAINTAINED** — what is still missing.
+
+### Verdict
+PASS — all BLOCK findings accepted; implementation may proceed.
+OR
+BLOCK — N finding(s) still unresolved; escalate to human.
+
+---
+
+## Original Brief
+
+STATIC
+  cat "$BRIEF_FILE" >> "$PROMPT_TMP"
+  printf '\n\n---\n\n## Orchestrator'\''s Response\n\n' >> "$PROMPT_TMP"
+  cat "$ARGOS_BRIEF_RESPONSE" >> "$PROMPT_TMP"
+
+elif [[ "$MODE" == "impl" && "$ROUND" == "1" ]]; then
+  [[ -f "$BRIEF_FILE" ]] || { echo "Error: brief not found at ${BRIEF_FILE}" >&2; exit 1; }
+
+  DIFF=$(git diff main..story/"${TASK_ID}" 2>/dev/null \
+      || git diff origin/main..HEAD 2>/dev/null \
+      || echo "(diff unavailable)")
+
+  printf 'You are an independent architecture reviewer for the %s project. You have no loyalty to the implementation'\''s framing — your job is to find problems before they are tested and merged.\n\n' \
+    "$PROJECT_NAME" >> "$PROMPT_TMP"
+  cat >> "$PROMPT_TMP" <<'STATIC'
+Your discipline:
+- Any claim about runtime behaviour — execution ordering, library defaults, middleware sequencing, plugin lifecycle, external state — is a hypothesis until verified from source (library code or official docs). Treat unverified runtime claims as BLOCK findings.
+- Be adversarial to the framing you are given. Your job is to find problems, not validate decisions.
+
+Also check:
+- Implementation matches the brief's acceptance criteria.
+- Correctness bugs, security issues, spec drift.
+- Error paths are handled.
+
+Output format (use exactly this structure):
+STATIC
+  printf '\n## Implementation Review — %s (Round 1)\n' "$TASK_ID" >> "$PROMPT_TMP"
+  cat >> "$PROMPT_TMP" <<'STATIC'
+
+### BLOCK findings
+Each as: **[B-N]** file:line — description — why it blocks — remediation.
+If none: "None."
+
+### WARN findings
+Each as: **[W-N]** file:line — description — recommendation.
+If none: "None."
+
+### NIT findings
+Each as: **[NIT-N]** file:line — description.
+If none: "None."
+
+### Verdict
+PASS — no BLOCK findings; testing may proceed.
+OR
+BLOCK — N blocking finding(s); must resolve before testing starts.
+
+---
+
+## Task Brief
+
+STATIC
+  cat "$BRIEF_FILE" >> "$PROMPT_TMP"
+  printf '\n\n---\n\n## Feature Handoff\n\n' >> "$PROMPT_TMP"
+  if [[ -f "$HANDOFF_FILE" ]]; then
+    cat "$HANDOFF_FILE" >> "$PROMPT_TMP"
+  else
+    printf '(no handoff file)\n' >> "$PROMPT_TMP"
+  fi
+  printf '\n\n---\n\n## Diff\n\n```diff\n' >> "$PROMPT_TMP"
+  # Diff is from git — controlled source, but still written via printf '%s'
+  # to avoid any printf format-string interpretation of diff content.
+  printf '%s\n' "$DIFF" >> "$PROMPT_TMP"
+  printf '```\n' >> "$PROMPT_TMP"
+
+else
+  # impl round 2
+  [[ -f "$ARGOS_IMPL_RESPONSE" ]] || { echo "Error: round 2 requires ${ARGOS_IMPL_RESPONSE}" >&2; exit 1; }
+
+  printf 'You are an independent architecture reviewer for the %s project. This is Round 2 — you previously raised BLOCK findings on the implementation, and the Orchestrator has responded. Evaluate each response.\n' \
+    "$PROJECT_NAME" >> "$PROMPT_TMP"
+  printf '\n## Implementation Review — %s (Round 2)\n' "$TASK_ID" >> "$PROMPT_TMP"
+  cat >> "$PROMPT_TMP" <<'STATIC'
+
+### BLOCK finding responses
+For each: **[B-N] ACCEPTED** — reason. OR **[B-N] MAINTAINED** — what is still missing.
+
+### Verdict
+PASS — all BLOCK findings accepted; testing may proceed.
+OR
+BLOCK — N finding(s) still unresolved; escalate to human.
+
+---
+
+## Orchestrator's Response
+
+STATIC
+  cat "$ARGOS_IMPL_RESPONSE" >> "$PROMPT_TMP"
+fi
+
+# ── Call OpenAI Responses API ─────────────────────────────────────────────────
+echo "→ Dual Review (mode: ${MODE}, round: ${ROUND}, task: ${TASK_ID}, model: ${MODEL})..." >&2
+
+if [[ "$MODEL" == o* ]]; then
+  jq -Rs --arg model "$MODEL" \
+    '{"model": $model, "input": ., "reasoning": {"effort": "high"}}' \
+    "$PROMPT_TMP" > "$PAYLOAD_TMP"
+else
+  jq -Rs --arg model "$MODEL" \
+    '{"model": $model, "input": .}' \
+    "$PROMPT_TMP" > "$PAYLOAD_TMP"
+fi
+
+RESPONSE=$(curl -s -X POST https://api.openai.com/v1/responses \
+  -H "Authorization: Bearer ${OPENAI_API_KEY}" \
+  -H "Content-Type: application/json" \
+  --data-binary "@${PAYLOAD_TMP}")
+
+OUTPUT=$(echo "$RESPONSE" \
+  | jq -r '.output[] | select(.type=="message") | .content[] | select(.type=="output_text") | .text' \
+  2>/dev/null)
+
+if [[ -z "$OUTPUT" ]]; then
+  echo "Error: no output from API. Full response:" >&2
+  echo "$RESPONSE" | jq . >&2
+  exit 1
+fi
+
+echo "$OUTPUT" > "$OUTPUT_FILE"
+echo "→ Review written to ${OUTPUT_FILE}" >&2
+echo "$OUTPUT"

--- a/.agents/scripts/pr-review.sh
+++ b/.agents/scripts/pr-review.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# pr-review.sh — Spec-enforcer PR review via `claude -p`
+#
+# Usage:
+#   .agents/scripts/pr-review.sh <PR-number> [--post] [--model <model>]
+#
+#   --post            Post the review as a GitHub PR comment via `gh pr review`.
+#   --model <model>   Override the model (default: $REVIEWER_MODEL, then
+#                     local_review.default_model from .agents/pr-review.yml,
+#                     then claude-sonnet-4-6).
+#
+# Prerequisites:
+#   - `claude` CLI installed and authenticated
+#   - `gh` CLI installed and authenticated
+#   - Run from the repo root (CLAUDE.md must be in cwd)
+
+set -euo pipefail
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+# ── Config reader (yq with grep fallback) ──────────────────────────────────
+CONFIG_FILE=".agents/pr-review.yml"
+
+cfg_get() {
+  local key="$1" fallback="${2:-}"
+  if [[ ! -f "$CONFIG_FILE" ]]; then echo "$fallback"; return; fi
+  if command -v yq &>/dev/null; then
+    local val
+    val=$(yq e "${key} // \"\"" "$CONFIG_FILE" 2>/dev/null)
+    echo "${val:-$fallback}"
+  else
+    local stripped="${key##*.}"
+    local val
+    val=$(grep -E "^\s*${stripped}:" "$CONFIG_FILE" 2>/dev/null | head -1 \
+          | sed 's/.*: *//;s/"//g;s/\r//')
+    echo "${val:-$fallback}"
+  fi
+}
+
+# ── Argument parsing ────────────────────────────────────────────────────────
+PR_NUMBER="${1:-}"
+POST_TO_GH=false
+
+DEFAULT_MODEL="${REVIEWER_MODEL:-}"
+[[ -z "$DEFAULT_MODEL" ]] && DEFAULT_MODEL="$(cfg_get '.local_review.default_model' 'claude-sonnet-4-6')"
+MODEL="$DEFAULT_MODEL"
+
+if [[ -z "$PR_NUMBER" ]]; then
+  echo "Usage: $0 <PR-number> [--post] [--model <model>]" >&2
+  exit 1
+fi
+
+shift
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --post)  POST_TO_GH=true; shift ;;
+    --model) MODEL="${2:?--model requires a value}"; shift 2 ;;
+    *)       echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ── Preflight checks ────────────────────────────────────────────────────────
+if [[ ! -f "CLAUDE.md" ]]; then
+  echo "Error: run from the repo root (CLAUDE.md not found in cwd)" >&2
+  exit 1
+fi
+
+for cmd in claude gh; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "Error: '$cmd' not found — install it first." >&2
+    exit 1
+  fi
+done
+
+# ── Fetch PR data ────────────────────────────────────────────────────────────
+echo "→ Fetching PR #${PR_NUMBER} metadata..." >&2
+PR_META=$(gh pr view "$PR_NUMBER" \
+  --json title,body,author,headRefName,baseRefName \
+  --template '## PR: {{.title}}
+Branch: {{.headRefName}} -> {{.baseRefName}}
+Author: {{.author.login}}
+
+### Description
+{{.body}}')
+
+echo "→ Fetching diff..." >&2
+PR_DIFF=$(gh pr diff "$PR_NUMBER")
+
+# ── Build prompt (safe injection) ───────────────────────────────────────────
+# Static template uses a QUOTED heredoc ('EOF') — no variable expansion.
+# Untrusted PR content is appended with printf '%s' (literal, no interpretation).
+PROJECT_NAME="$(cfg_get '.project.name' "$(basename "$PWD")")"
+
+PROMPT_FILE=$(mktemp /tmp/pr-review-XXXXXX.md)
+trap 'rm -f "$PROMPT_FILE"' EXIT
+
+cat > "$PROMPT_FILE" <<'ENDSTATIC'
+You are a Spec-enforcer. CLAUDE.md in this repo has been loaded automatically
+as your project context. Perform a thorough PR review now.
+
+## What to do
+
+1. Read every file in skills/ that is relevant to this diff.
+2. Check the diff against every forbidden pattern listed in CLAUDE.md under
+   "Forbidden patterns". Each is a BLOCK finding if present.
+3. Check docs/planning/decisions.md (if it exists) — verify the diff does not
+   contradict any locked decision.
+4. Check for missing tests: new routes or public functions must have corresponding
+   test files.
+5. Check for secrets committed: credentials, API keys, tokens → BLOCK immediately.
+6. Apply any project-specific rules documented in CLAUDE.md.
+
+## Output format (GitHub-rendered markdown)
+
+Open the review with a GitHub alert callout matching the verdict:
+
+- ✅ PASS  → `> [!TIP]`      (green)
+- ⚠️ WARN  → `> [!WARNING]`  (amber)
+- ❌ BLOCK → `> [!CAUTION]`  (red)
+- N/A      → `> [!NOTE]`     (blue — docs-only PRs where no rules apply)
+
+Do NOT include opening or closing `---` separators in the body.
+Use the section headers below exactly as written.
+
+ENDSTATIC
+
+# Append the PR number (script-controlled integer — safe to expand here).
+printf '## Spec-enforcer Review — PR #%s\n\n' "$PR_NUMBER" >> "$PROMPT_FILE"
+
+cat >> "$PROMPT_FILE" <<'ENDTEMPLATE'
+> [!TIP]
+> **Verdict:** ✅ PASS — <one-sentence reason>
+
+### Findings
+
+For each finding:
+- **[BLOCK | WARN | INFO]** `file:line` — description
+  - **Rule:** skill filename or CLAUDE.md section
+  - **Fix:** specific remediation
+
+(If no findings: "No findings. All checked patterns pass.")
+
+### Summary
+
+2–3 sentence plain-English summary of what the PR does and whether it can merge.
+
+ENDTEMPLATE
+
+# Append untrusted content with printf '%s' (argument, not format string) to
+# prevent shell metacharacter expansion from PR titles, bodies, or diff lines.
+printf '## PR metadata\n' >> "$PROMPT_FILE"
+printf '%s\n' "$PR_META" >> "$PROMPT_FILE"
+printf '\n## Diff\n' >> "$PROMPT_FILE"
+printf '%s\n' "$PR_DIFF" >> "$PROMPT_FILE"
+
+# ── Run review ───────────────────────────────────────────────────────────────
+echo "→ Running Spec-enforcer review via claude -p --model ${MODEL}..." >&2
+
+START_TIME=$(date +%s)
+
+# Pass prompt via stdin (< file) — avoids command-line length limits and
+# prevents any $(...) or backtick expansion in untrusted diff content.
+#
+# --allowedTools restricts Claude to read-only file operations so that
+# prompt-injected instructions in an attacker's PR diff cannot execute
+# arbitrary shell commands. The reviewer only needs to read skills/ and
+# docs/planning/ — no write, bash, or network access required.
+REVIEW=$(claude -p --model "$MODEL" \
+  --allowedTools "Read,Glob,Grep" \
+  < "$PROMPT_FILE") || {
+  echo "Error: claude -p exited with code $?" >&2
+  echo "Tip: check \`claude auth status\` and confirm PATH includes homebrew bins." >&2
+  exit 1
+}
+
+END_TIME=$(date +%s)
+ELAPSED=$(( END_TIME - START_TIME ))
+
+# ── Append footer ────────────────────────────────────────────────────────────
+TZ_LOCAL="$(cfg_get '.project.timezone' 'America/Los_Angeles')"
+TIMESTAMP_LOCAL=$(TZ="$TZ_LOCAL" date '+%Y-%m-%d %H:%M %Z' 2>/dev/null || date '+%Y-%m-%d %H:%M %Z')
+TIMESTAMP_UTC=$(date -u '+%Y-%m-%d %H:%M UTC')
+
+REVIEW="${REVIEW}
+
+---
+🤖 **Reviewer:** Spec-enforcer · **Project:** ${PROJECT_NAME} · **Model:** \`${MODEL}\` · **Elapsed:** ${ELAPSED}s · **Generated:** ${TIMESTAMP_LOCAL} · ${TIMESTAMP_UTC}"
+
+# ── Output ───────────────────────────────────────────────────────────────────
+echo ""
+echo "════════════════════════════════════════"
+echo "$REVIEW"
+echo "════════════════════════════════════════"
+
+if [[ "$POST_TO_GH" == "true" ]]; then
+  echo "" >&2
+  echo "→ Posting review to PR #${PR_NUMBER}..." >&2
+  gh pr review "$PR_NUMBER" --comment --body "$REVIEW"
+  echo "→ Posted." >&2
+fi

--- a/.agents/scripts/setup-pr-review.sh
+++ b/.agents/scripts/setup-pr-review.sh
@@ -1,0 +1,467 @@
+#!/usr/bin/env bash
+# setup-pr-review.sh — Interactive wizard that generates .agents/pr-review.yml
+#
+# Usage:
+#   .agents/scripts/setup-pr-review.sh [--update]
+#
+# Flags:
+#   --update   Re-run over an existing config (prompts show current values as defaults)
+#
+# Prerequisites detected automatically:
+#   gh CLI authenticated, claude CLI authenticated,
+#   DEEPSEEK_API_KEY / OPENAI_API_KEY in env or .env,
+#   GitHub remote present, Playwright in package.json / pyproject.toml
+#
+# After running: copy or symlink the canonical scripts and workflow templates
+# from ai_guidance/pipelines/pr-reviewer/ into this project.
+
+set -euo pipefail
+
+# ── Colours ────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+CYAN='\033[0;36m'; BOLD='\033[1m'; RESET='\033[0m'
+
+info()    { echo -e "${CYAN}▸${RESET} $*"; }
+ok()      { echo -e "${GREEN}✓${RESET} $*"; }
+warn()    { echo -e "${YELLOW}⚠${RESET}  $*"; }
+err()     { echo -e "${RED}✗${RESET} $*"; }
+heading() { echo -e "\n${BOLD}$*${RESET}"; }
+divider() { echo -e "${CYAN}────────────────────────────────────────────${RESET}"; }
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+# ask <prompt> <default>  →  prints answer to stdout
+ask() {
+  local prompt="$1" default="$2"
+  local display_default=""
+  [[ -n "$default" ]] && display_default=" [${default}]"
+  echo -en "${BOLD}${prompt}${RESET}${display_default}: " >&2
+  local answer
+  read -r answer
+  echo "${answer:-$default}"
+}
+
+# ask_yn <prompt> <default y|n>  →  exits 0 for yes, 1 for no
+ask_yn() {
+  local prompt="$1" default="${2:-n}"
+  local choices="y/n"
+  [[ "$default" == "y" ]] && choices="Y/n" || choices="y/N"
+  echo -en "${BOLD}${prompt}${RESET} (${choices}): " >&2
+  local answer
+  read -r answer
+  answer="${answer:-$default}"
+  [[ "${answer,,}" == "y" ]]
+}
+
+# yq_get <file> <key> <fallback>
+yq_get() {
+  local file="$1" key="$2" fallback="${3:-}"
+  if command -v yq &>/dev/null; then
+    yq e "${key} // \"${fallback}\"" "$file" 2>/dev/null || echo "$fallback"
+  else
+    # plain-grep fallback — handles simple scalar values
+    local stripped="${key##*.}"
+    grep -E "^\s*${stripped}:" "$file" 2>/dev/null \
+      | head -1 | sed 's/.*: *//;s/"//g;s/\r//' || echo "$fallback"
+  fi
+}
+
+# ── Phase 1: Silent detection ───────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+CONFIG_FILE="${PROJECT_ROOT}/.agents/pr-review.yml"
+UPDATE_MODE=false
+[[ "${1:-}" == "--update" ]] && UPDATE_MODE=true
+
+heading "PR Reviewer Setup Wizard"
+divider
+info "Detecting environment…"
+
+# Existing config
+EXISTING_CONFIG=false
+[[ -f "$CONFIG_FILE" ]] && EXISTING_CONFIG=true
+
+if $EXISTING_CONFIG && ! $UPDATE_MODE; then
+  warn "Config already exists at .agents/pr-review.yml"
+  if ! ask_yn "Re-run wizard to update it?" "n"; then
+    info "Aborting. Run with --update to force."
+    exit 0
+  fi
+  UPDATE_MODE=true
+fi
+
+# GitHub remote
+HAS_REMOTE=false
+GITHUB_REMOTE=""
+if git remote get-url origin &>/dev/null 2>&1; then
+  GITHUB_REMOTE="$(git remote get-url origin 2>/dev/null)"
+  if [[ "$GITHUB_REMOTE" == *github.com* ]]; then
+    HAS_REMOTE=true
+    ok "GitHub remote: ${GITHUB_REMOTE}"
+  else
+    warn "Remote found but not GitHub: ${GITHUB_REMOTE}"
+  fi
+else
+  warn "No git remote found — CI features will be skipped"
+fi
+
+# gh CLI
+GH_AUTHED=false
+if command -v gh &>/dev/null && gh auth status &>/dev/null 2>&1; then
+  GH_AUTHED=true
+  ok "gh CLI: authenticated"
+else
+  warn "gh CLI: not authenticated (run: gh auth login)"
+fi
+
+# claude CLI
+CLAUDE_AUTHED=false
+if command -v claude &>/dev/null; then
+  CLAUDE_AUTHED=true
+  ok "claude CLI: found"
+else
+  warn "claude CLI: not found (local review will be skipped)"
+fi
+
+# DeepSeek API key
+DEEPSEEK_KEY=false
+if [[ -n "${DEEPSEEK_API_KEY:-}" ]]; then
+  DEEPSEEK_KEY=true
+  ok "DEEPSEEK_API_KEY: found in environment"
+elif [[ -f "${PROJECT_ROOT}/.env" ]] && grep -q "DEEPSEEK_API_KEY" "${PROJECT_ROOT}/.env" 2>/dev/null; then
+  DEEPSEEK_KEY=true
+  ok "DEEPSEEK_API_KEY: found in .env"
+else
+  warn "DEEPSEEK_API_KEY: not found (PR-Agent CI will need it as a GitHub secret)"
+fi
+
+# OpenAI API key (for O3 dual-review)
+OPENAI_KEY=false
+if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+  OPENAI_KEY=true
+  ok "OPENAI_API_KEY: found in environment"
+elif [[ -f "${PROJECT_ROOT}/.env" ]] && grep -q "OPENAI_API_KEY" "${PROJECT_ROOT}/.env" 2>/dev/null; then
+  OPENAI_KEY=true
+  ok "OPENAI_API_KEY: found in .env"
+else
+  warn "OPENAI_API_KEY: not found (O3 dual-review will be skipped)"
+fi
+
+# Playwright
+HAS_PLAYWRIGHT=false
+if [[ -f "${PROJECT_ROOT}/package.json" ]] && grep -q "playwright" "${PROJECT_ROOT}/package.json" 2>/dev/null; then
+  HAS_PLAYWRIGHT=true
+  ok "Playwright: detected in package.json"
+elif [[ -f "${PROJECT_ROOT}/pyproject.toml" ]] && grep -q "playwright" "${PROJECT_ROOT}/pyproject.toml" 2>/dev/null; then
+  HAS_PLAYWRIGHT=true
+  ok "Playwright: detected in pyproject.toml"
+else
+  warn "Playwright: not detected (test tiers T2+ will be skipped)"
+fi
+
+# Pull defaults from existing config when in update mode
+cfg_get() {
+  local key="$1" fallback="${2:-}"
+  if $UPDATE_MODE && $EXISTING_CONFIG; then
+    yq_get "$CONFIG_FILE" "$key" "$fallback"
+  else
+    echo "$fallback"
+  fi
+}
+
+# ── Phase 2: Questions ──────────────────────────────────────────────────────
+
+divider
+heading "Project"
+
+PROJECT_NAME="$(cfg_get '.project.name' "$(basename "$PROJECT_ROOT")")"
+PROJECT_NAME="$(ask "Project name" "$PROJECT_NAME")"
+
+PROJECT_TZ="$(cfg_get '.project.timezone' "America/Los_Angeles")"
+PROJECT_TZ="$(ask "Timezone (for review footers)" "$PROJECT_TZ")"
+
+# ── PR-Agent CI ──
+PR_AGENT_ENABLED=false
+PR_AGENT_SKIP_DOCS=false
+PR_AGENT_STATUS_CHECK=true
+PR_AGENT_CANCEL=true
+PR_AGENT_HIGH_STAKES="high-stakes"
+PR_AGENT_MODEL="deepseek/deepseek-v4-pro"
+
+if $HAS_REMOTE; then
+  divider
+  heading "PR-Agent CI (GitHub Actions)"
+  info "Requires DEEPSEEK_API_KEY as a GitHub secret."
+  _default_pra="$(cfg_get '.pr_agent.enabled' 'n')"; [[ "$_default_pra" == "true" ]] && _default_pra="y"
+  if ask_yn "Enable PR-Agent automated review?" "$_default_pra"; then
+    PR_AGENT_ENABLED=true
+
+    if ! $DEEPSEEK_KEY; then
+      warn "DEEPSEEK_API_KEY not found locally."
+      info "Make sure the secret is set in GitHub: gh secret set DEEPSEEK_API_KEY"
+    fi
+
+    PR_AGENT_MODEL="$(cfg_get '.pr_agent.model' 'deepseek/deepseek-v4-pro')"
+    PR_AGENT_MODEL="$(ask "PR-Agent model" "$PR_AGENT_MODEL")"
+
+    PR_AGENT_HIGH_STAKES="$(cfg_get '.pr_agent.high_stakes_label' 'high-stakes')"
+    PR_AGENT_HIGH_STAKES="$(ask "High-stakes label name" "$PR_AGENT_HIGH_STAKES")"
+
+    _default_skip="$(cfg_get '.pr_agent.skip_docs_only' 'n')"; [[ "$_default_skip" == "true" ]] && _default_skip="y"
+    ask_yn "Skip review for docs-only / planning-only PRs?" "$_default_skip" && PR_AGENT_SKIP_DOCS=true
+
+    _default_sc="$(cfg_get '.pr_agent.status_check' 'y')"; [[ "$_default_sc" == "false" ]] && _default_sc="n"
+    ask_yn "Post a commit status check (green/red) after review?" "${_default_sc:-y}" && PR_AGENT_STATUS_CHECK=true || PR_AGENT_STATUS_CHECK=false
+
+    _default_cif="$(cfg_get '.pr_agent.cancel_in_flight' 'y')"; [[ "$_default_cif" == "false" ]] && _default_cif="n"
+    ask_yn "Cancel in-flight review when a new commit is pushed?" "${_default_cif:-y}" && PR_AGENT_CANCEL=true || PR_AGENT_CANCEL=false
+  fi
+else
+  warn "Skipping PR-Agent CI (no GitHub remote)"
+fi
+
+# ── Local review ──
+LOCAL_ENABLED=false
+LOCAL_MODEL="claude-sonnet-4-6"
+LOCAL_ALIAS=""
+
+if $CLAUDE_AUTHED; then
+  divider
+  heading "Local review (claude -p)"
+  _default_local="$(cfg_get '.local_review.enabled' 'n')"; [[ "$_default_local" == "true" ]] && _default_local="y"
+  if ask_yn "Enable local review script (pr-review.sh)?" "$_default_local"; then
+    LOCAL_ENABLED=true
+
+    LOCAL_MODEL="$(cfg_get '.local_review.default_model' 'claude-sonnet-4-6')"
+    LOCAL_MODEL="$(ask "Default model for local review" "$LOCAL_MODEL")"
+
+    LOCAL_ALIAS="$(cfg_get '.local_review.shell_alias' '')"
+    LOCAL_ALIAS="$(ask "Shell alias (e.g. pr:review — leave blank to skip)" "$LOCAL_ALIAS")"
+  fi
+else
+  warn "Skipping local review (claude CLI not found)"
+fi
+
+# ── O3 dual-review ──
+DUAL_ENABLED=false
+DUAL_MODEL="o3"
+DUAL_BRIEF=true
+DUAL_IMPL=true
+
+if $OPENAI_KEY; then
+  divider
+  heading "O3 dual-review (independent architecture gate)"
+  info "Fires during the implement loop: before implementation (brief) and/or after (impl)."
+  _default_dual="$(cfg_get '.dual_review.enabled' 'n')"; [[ "$_default_dual" == "true" ]] && _default_dual="y"
+  if ask_yn "Enable O3 dual-review?" "$_default_dual"; then
+    DUAL_ENABLED=true
+
+    DUAL_MODEL="$(cfg_get '.dual_review.model' 'o3')"
+    DUAL_MODEL="$(ask "Dual-review model" "$DUAL_MODEL")"
+
+    _default_brief="$(cfg_get '.dual_review.on_brief' 'y')"; [[ "$_default_brief" == "false" ]] && _default_brief="n"
+    ask_yn "Review the task brief (Phase 4)?" "${_default_brief:-y}" || DUAL_BRIEF=false
+
+    _default_impl="$(cfg_get '.dual_review.on_impl' 'y')"; [[ "$_default_impl" == "false" ]] && _default_impl="n"
+    ask_yn "Review the implementation (Phase 7)?" "${_default_impl:-y}" || DUAL_IMPL=false
+  fi
+else
+  warn "Skipping O3 dual-review (OPENAI_API_KEY not found)"
+fi
+
+# ── DCO ──
+DCO_ENABLED=false
+
+if $HAS_REMOTE; then
+  divider
+  heading "DCO sign-off enforcement"
+  info "Adds a dco.yml GitHub Actions workflow requiring Signed-off-by on all commits."
+  _default_dco="$(cfg_get '.dco.enabled' 'n')"; [[ "$_default_dco" == "true" ]] && _default_dco="y"
+  ask_yn "Enable DCO enforcement?" "$_default_dco" && DCO_ENABLED=true
+fi
+
+# ── PR template ──
+PR_TEMPLATE_ENABLED=false
+
+divider
+heading "PR body template"
+info "Installs .github/pull_request_template.md with acceptance-criteria checklist."
+_default_pt="$(cfg_get '.pr_template.enabled' 'n')"; [[ "$_default_pt" == "true" ]] && _default_pt="y"
+ask_yn "Enable PR template?" "$_default_pt" && PR_TEMPLATE_ENABLED=true
+
+# ── Test tiers ──
+TIER_T1=true
+TIER_T2=false
+TIER_T25=false
+TIER_T3=false
+
+if $HAS_PLAYWRIGHT; then
+  divider
+  heading "Test tier hierarchy"
+  info "Controls which tiers the test-writer agent is expected to produce."
+  info "T1 Headless is always on. Higher tiers require Playwright."
+
+  _default_t2="$(cfg_get '.test_tiers.t2_aria' 'n')"; [[ "$_default_t2" == "true" ]] && _default_t2="y"
+  ask_yn "T2 ARIA — accessibility tree for unauthenticated routes?" "$_default_t2" && TIER_T2=true
+
+  _default_t25="$(cfg_get '.test_tiers.t2_5_authenticated' 'n')"; [[ "$_default_t25" == "true" ]] && _default_t25="y"
+  ask_yn "T2.5 Authenticated — ARIA tree for logged-in routes?" "$_default_t25" && TIER_T25=true
+
+  _default_t3="$(cfg_get '.test_tiers.t3_visual' 'n')"; [[ "$_default_t3" == "true" ]] && _default_t3="y"
+  ask_yn "T3 Visual — screenshot sign-off per design slice?" "$_default_t3" && TIER_T3=true
+else
+  warn "Skipping test tiers T2+ (Playwright not detected)"
+fi
+
+# ── Phase 3: Write config ────────────────────────────────────────────────────
+
+divider
+heading "Writing config"
+
+mkdir -p "${PROJECT_ROOT}/.agents"
+
+cat > "$CONFIG_FILE" <<YAML
+# .agents/pr-review.yml
+# Generated by setup-pr-review.sh on $(date '+%Y-%m-%d').
+# Re-run .agents/scripts/setup-pr-review.sh --update to change settings.
+
+project:
+  name: "${PROJECT_NAME}"
+  timezone: "${PROJECT_TZ}"
+
+pr_agent:
+  enabled: ${PR_AGENT_ENABLED}
+  model: "${PR_AGENT_MODEL}"
+  max_tokens: 131072
+  output_tokens: 64000
+  high_stakes_label: "${PR_AGENT_HIGH_STAKES}"
+  skip_docs_only: ${PR_AGENT_SKIP_DOCS}
+  score_labels: true
+  score_banner: true
+  status_check: ${PR_AGENT_STATUS_CHECK}
+  cancel_in_flight: ${PR_AGENT_CANCEL}
+
+local_review:
+  enabled: ${LOCAL_ENABLED}
+  default_model: "${LOCAL_MODEL}"
+  shell_alias: "${LOCAL_ALIAS}"
+
+dual_review:
+  enabled: ${DUAL_ENABLED}
+  model: "${DUAL_MODEL}"
+  on_brief: ${DUAL_BRIEF}
+  on_impl: ${DUAL_IMPL}
+
+dco:
+  enabled: ${DCO_ENABLED}
+
+pr_template:
+  enabled: ${PR_TEMPLATE_ENABLED}
+
+test_tiers:
+  t1_headless: ${TIER_T1}
+  t2_aria: ${TIER_T2}
+  t2_5_authenticated: ${TIER_T25}
+  t3_visual: ${TIER_T3}
+YAML
+
+ok "Written: .agents/pr-review.yml"
+
+# ── Generate shell-aliases.sh if alias configured ────────────────────────────
+if [[ -n "$LOCAL_ALIAS" ]]; then
+  ALIASES_FILE="${PROJECT_ROOT}/.agents/scripts/shell-aliases.sh"
+  TEMPLATE_SRC=""
+  # Find the template relative to this wizard (works from ai_guidance or copied location)
+  _wizard_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  if [[ -f "${_wizard_dir}/shell-aliases.sh" ]]; then
+    TEMPLATE_SRC="${_wizard_dir}/shell-aliases.sh"
+  fi
+
+  if [[ -n "$TEMPLATE_SRC" ]]; then
+    mkdir -p "${PROJECT_ROOT}/.agents/scripts"
+    sed "s/@@ALIAS@@/${LOCAL_ALIAS}/g" "$TEMPLATE_SRC" > "$ALIASES_FILE"
+    chmod +x "$ALIASES_FILE"
+    ok "Generated: .agents/scripts/shell-aliases.sh  (alias: ${LOCAL_ALIAS})"
+  else
+    warn "shell-aliases.sh template not found alongside wizard — generate manually."
+  fi
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+divider
+heading "Summary"
+
+print_feature() {
+  local name="$1" enabled="$2" note="${3:-}"
+  if [[ "$enabled" == "true" ]]; then
+    ok "${name}${note:+  (${note})}"
+  else
+    err "${name}${note:+  — ${note}}"
+  fi
+}
+
+print_feature "PR-Agent CI"       "$PR_AGENT_ENABLED"    "$($PR_AGENT_ENABLED && echo "model: ${PR_AGENT_MODEL}" || echo "no GitHub remote or not opted in")"
+print_feature "Local review"      "$LOCAL_ENABLED"       "$($LOCAL_ENABLED && echo "model: ${LOCAL_MODEL}" || echo "claude CLI not found or not opted in")"
+print_feature "Shell alias"       "$([[ -n "$LOCAL_ALIAS" ]] && echo true || echo false)"  "${LOCAL_ALIAS:-not configured}"
+print_feature "O3 dual-review"    "$DUAL_ENABLED"        "$($DUAL_ENABLED && echo "model: ${DUAL_MODEL}" || echo "OPENAI_API_KEY not found or not opted in")"
+print_feature "DCO enforcement"   "$DCO_ENABLED"
+print_feature "PR template"       "$PR_TEMPLATE_ENABLED"
+print_feature "T2 ARIA"           "$TIER_T2"             "$($TIER_T2 || $HAS_PLAYWRIGHT && echo "" || echo "Playwright not detected")"
+print_feature "T2.5 Authenticated" "$TIER_T25"
+print_feature "T3 Visual"         "$TIER_T3"
+
+# ── Next steps ───────────────────────────────────────────────────────────────
+
+divider
+heading "Next steps"
+
+NEXT=0
+
+if $PR_AGENT_ENABLED && ! $DEEPSEEK_KEY; then
+  NEXT=$((NEXT+1))
+  echo -e "  ${NEXT}. Add DEEPSEEK_API_KEY to GitHub secrets:"
+  echo    "       gh secret set DEEPSEEK_API_KEY"
+fi
+
+if $PR_AGENT_ENABLED; then
+  NEXT=$((NEXT+1))
+  echo -e "  ${NEXT}. Copy the canonical GitHub Actions workflow:"
+  echo    "       cp \$AI_GUIDANCE/pipelines/pr-reviewer/templates/pr-review.yml .github/workflows/"
+fi
+
+if $DCO_ENABLED; then
+  NEXT=$((NEXT+1))
+  echo -e "  ${NEXT}. Copy the DCO workflow:"
+  echo    "       cp \$AI_GUIDANCE/pipelines/pr-reviewer/templates/dco.yml .github/workflows/"
+fi
+
+if $PR_TEMPLATE_ENABLED; then
+  NEXT=$((NEXT+1))
+  echo -e "  ${NEXT}. Copy the PR body template:"
+  echo    "       cp \$AI_GUIDANCE/pipelines/pr-reviewer/templates/pull_request_template.md .github/"
+fi
+
+if $LOCAL_ENABLED || $DUAL_ENABLED; then
+  NEXT=$((NEXT+1))
+  echo -e "  ${NEXT}. Copy the canonical scripts:"
+  echo    "       cp \$AI_GUIDANCE/pipelines/pr-reviewer/scripts/*.sh .agents/scripts/"
+  echo    "       chmod +x .agents/scripts/*.sh"
+fi
+
+if [[ -n "$LOCAL_ALIAS" ]]; then
+  NEXT=$((NEXT+1))
+  echo -e "  ${NEXT}. Source the shell alias in your shell config:"
+  echo    "       echo 'source \$(git rev-parse --show-toplevel)/.agents/scripts/shell-aliases.sh' >> ~/.zshrc"
+fi
+
+if $PR_AGENT_ENABLED || $LOCAL_ENABLED; then
+  NEXT=$((NEXT+1))
+  echo -e "  ${NEXT}. Verify everything is ready:"
+  echo    "       .agents/scripts/check-pr-review-readiness.sh"
+fi
+
+[[ $NEXT -eq 0 ]] && info "Nothing else to do — all features are self-contained."
+
+echo ""

--- a/.agents/scripts/shell-aliases.sh
+++ b/.agents/scripts/shell-aliases.sh
@@ -1,0 +1,32 @@
+# shell-aliases.sh — Project shell shortcuts for PR review
+#
+# Generated/installed by setup-pr-review.sh based on local_review.shell_alias
+# in .agents/pr-review.yml.
+#
+# Source this from your shell profile (zsh only — colon function names like
+# `pr:review` are legal in zsh but a parse error in bash):
+#
+#   echo 'source /path/to/project/.agents/scripts/shell-aliases.sh' >> ~/.zshrc
+#
+# Or source it per-session:
+#   source .agents/scripts/shell-aliases.sh
+#
+# The PROJECT_DIR variable is auto-detected from the location of this script.
+# Override it in your profile if needed:
+#   export PROJECT_DIR="$HOME/alt/path/to/project"
+
+PROJECT_DIR="${PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/../.." && pwd)}"
+
+# @@ALIAS@@ — run the Spec-enforcer PR review via `claude -p`
+# Usage:
+#   @@ALIAS@@ <PR-number>              print review to stdout
+#   @@ALIAS@@ <PR-number> --post       also post as a PR comment
+#   @@ALIAS@@ <PR-number> --model X    override the default model
+@@ALIAS@@() {
+  if [[ ! -d "$PROJECT_DIR" ]]; then
+    echo "@@ALIAS@@: PROJECT_DIR not found: $PROJECT_DIR" >&2
+    echo "         Set PROJECT_DIR in your shell profile if the repo moved." >&2
+    return 1
+  fi
+  ( cd "$PROJECT_DIR" && ./.agents/scripts/pr-review.sh "$@" )
+}

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+## Summary
+
+<!-- 1–3 sentences describing what this PR ships and why -->
+
+## Linked issue(s)
+
+Issue: <!-- e.g. #12 -->
+Epic: <!-- e.g. #90 -->
+
+## Acceptance criteria
+
+<!-- Copy the acceptance criteria from the linked issue. Check every box before opening. -->
+
+- [ ] <criterion 1>
+- [ ] <criterion 2>
+
+## Checklist
+
+| Item | Status | Notes |
+|---|---|---|
+| No secrets committed (credentials, tokens, API keys) | yes / N/A | |
+| New routes or public functions have corresponding tests | yes / N/A | |
+| Forbidden patterns from CLAUDE.md are not present | yes / N/A | |
+| Spec / skills are not contradicted | yes / N/A | |
+
+<!-- Project-specific rows: copy from your CLAUDE.md checklist and add here -->
+
+## Decisions that deviate from spec
+
+<!-- Any decision not pinned in docs/planning/* or skills/*.
+     Format: what · why · which doc it adjoins.
+     If none: "None." -->
+
+- None.
+
+## Apply `high-stakes` label if this PR touches
+
+<!-- List your project's high-stakes triggers here, e.g.:
+     Auth config, credentials in .env.example, commercial/EE code,
+     network/port exposure, public API contracts, migrations. -->

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,48 @@
+name: DCO sign-off check
+
+# Requires every commit in a PR to carry a Signed-off-by trailer.
+# Enable via dco.enabled: true in .agents/pr-review.yml.
+#
+# Format: Signed-off-by: Your Name <you@example.com>
+# Add with: git commit -s   or   git commit --signoff
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  statuses: write
+
+concurrency:
+  group: dco-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  dco:
+    name: DCO sign-off check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Check DCO sign-off on all commits
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          MISSING=0
+          while IFS= read -r SHA; do
+            [ -z "$SHA" ] && continue
+            if ! git log -1 --format="%B" "$SHA" | grep -qE "^Signed-off-by: .+ <.+@.+>"; then
+              SUBJECT=$(git log -1 --format="%s" "$SHA")
+              echo "::error::Commit $SHA ('$SUBJECT') is missing a Signed-off-by trailer."
+              MISSING=$((MISSING + 1))
+            fi
+          done < <(git log --no-merges --format="%H" "$BASE..$HEAD")
+          if [ "$MISSING" -gt 0 ]; then
+            echo "::error::$MISSING commit(s) missing DCO sign-off."
+            echo "::error::Add it with: git commit -s  or  git commit --signoff"
+            exit 1
+          fi
+          echo "All commits have DCO sign-off."

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -260,13 +260,13 @@ jobs:
           rm -f /tmp/pr-body-current.md.bak
 
           cat > /tmp/pr-body-banner.md <<EOFBANNER
-<!-- argos-status:start -->
-> ${EMOJI} **PR-Agent Score: ${SCORE}** \`${BRACKET}\` · model: \`${MODEL_SHORT}\`
-> 🔒 **Security:** ${SEC} · ⚡ **Major:** ${MAJOR} · 🔍 **Minor:** ${MINOR}
-> **Triggered by** ${TRIGGER_DESC}${SPECIFIC} · run [#${RUN_ID}](${RUN_URL}) · ${NOW_DISPLAY}
-<!-- argos-status:end -->
+          <!-- argos-status:start -->
+          > ${EMOJI} **PR-Agent Score: ${SCORE}** \`${BRACKET}\` · model: \`${MODEL_SHORT}\`
+          > 🔒 **Security:** ${SEC} · ⚡ **Major:** ${MAJOR} · 🔍 **Minor:** ${MINOR}
+          > **Triggered by** ${TRIGGER_DESC}${SPECIFIC} · run [#${RUN_ID}](${RUN_URL}) · ${NOW_DISPLAY}
+          <!-- argos-status:end -->
 
-EOFBANNER
+          EOFBANNER
 
           cat /tmp/pr-body-banner.md /tmp/pr-body-current.md > /tmp/pr-body-new.md
           gh pr edit "$PR_NUM" --body-file /tmp/pr-body-new.md --repo "${REPO}"

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,315 @@
+name: PR-Agent Spec Review
+
+# ── Canonical template from ai_guidance/pipelines/pr-reviewer/
+# Feature flags are driven by .agents/pr-review.yml in the project root.
+# A "Read config" step at the start of the job sets GITHUB_OUTPUT entries
+# that subsequent steps gate on.
+#
+# DISPLAY_TZ repo variable (optional): set in GitHub → repo → Settings →
+# Variables → Actions to localise banner timestamps (e.g. "America/Los_Angeles").
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+  issue_comment:
+    types: [created]   # slash commands: /review /describe /improve /ask
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  statuses: write   # required for the commit status check step
+
+concurrency:
+  group: pr-agent-${{ github.event.pull_request.number || github.event.issue.number }}
+  # Cancel in-flight reviews when a newer commit lands.
+  # Controlled by pr_agent.cancel_in_flight — set cancel-in-progress: false
+  # in a project fork of this template if the flag is off.
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true   # Node 20 deprecated June 2026
+
+jobs:
+  pr-agent:
+    # Skip bot-authored events and drafts (unless slash-command triggered).
+    #
+    # The issue_comment filter — startsWith(comment.body, '/') — prevents
+    # random PR comments (app notifications, human chatter) from triggering
+    # a review run and then being cancelled by cancel-in-progress, which would
+    # abort a legitimate in-flight review. Only explicit slash commands fire.
+    if: |
+      github.event.sender.type != 'Bot' &&
+      (!github.event.pull_request.draft || github.event.issue.pull_request) &&
+      (github.event_name != 'issue_comment' ||
+       startsWith(github.event.comment.body, '/review') ||
+       startsWith(github.event.comment.body, '/describe') ||
+       startsWith(github.event.comment.body, '/improve') ||
+       startsWith(github.event.comment.body, '/ask'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      # ── Read project config ──────────────────────────────────────────────
+      # Parses .agents/pr-review.yml (if present) and exports feature flags
+      # as GITHUB_OUTPUT. Falls back to safe defaults when the file is absent.
+      - name: Read pr-review config
+        id: cfg
+        run: |
+          CONFIG=".agents/pr-review.yml"
+          if command -v yq &>/dev/null; then
+            get() { yq e "${1} // \"${2}\"" "$CONFIG" 2>/dev/null || echo "$2"; }
+          else
+            get() {
+              local k="${1##*.}" d="$2"
+              grep -E "^\s*${k}:" "$CONFIG" 2>/dev/null | head -1 \
+                | sed 's/.*: *//;s/"//g;s/\r//' || echo "$d"
+            }
+          fi
+
+          if [[ -f "$CONFIG" ]]; then
+            HIGH_STAKES_LABEL="$(get '.pr_agent.high_stakes_label' 'high-stakes')"
+            SCORE_LABELS="$(get '.pr_agent.score_labels' 'true')"
+            SCORE_BANNER="$(get '.pr_agent.score_banner' 'true')"
+            STATUS_CHECK="$(get '.pr_agent.status_check' 'true')"
+            MODEL="$(get '.pr_agent.model' 'deepseek/deepseek-v4-pro')"
+          else
+            HIGH_STAKES_LABEL="high-stakes"
+            SCORE_LABELS="true"
+            SCORE_BANNER="true"
+            STATUS_CHECK="true"
+            MODEL="deepseek/deepseek-v4-pro"
+          fi
+
+          {
+            echo "high_stakes_label=${HIGH_STAKES_LABEL}"
+            echo "score_labels=${SCORE_LABELS}"
+            echo "score_banner=${SCORE_BANNER}"
+            echo "status_check=${STATUS_CHECK}"
+            echo "model=${MODEL}"
+          } >> "$GITHUB_OUTPUT"
+
+      # ── Resolve PR labels ────────────────────────────────────────────────
+      # github.event.pull_request.labels is null for issue_comment events.
+      # Fetch live labels so the high-stakes check works for /review too.
+      - name: Resolve PR labels
+        id: labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HIGH_STAKES_LABEL: ${{ steps.cfg.outputs.high_stakes_label }}
+        run: |
+          PR_NUM="${{ github.event.pull_request.number || github.event.issue.number }}"
+          if [[ -z "$PR_NUM" || "$PR_NUM" == "null" ]]; then
+            echo "high_stakes=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          LABELS=$(gh pr view "$PR_NUM" --repo "${{ github.repository }}" \
+            --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+          if echo "$LABELS" | grep -qF "$HIGH_STAKES_LABEL"; then
+            echo "high_stakes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "high_stakes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ── PR-Agent review (default) ────────────────────────────────────────
+      # qodo-ai/pr-agent is pinned to a commit SHA, not @main, so upstream
+      # behavior changes can't silently alter review output. Bump deliberately:
+      #   1. gh api repos/qodo-ai/pr-agent/commits/main -q '.sha'
+      #   2. update both SHA references below
+      #   3. open a PR — PR-Agent reviews itself with the new SHA
+      - name: PR-Agent review (default)
+        id: review-default
+        if: ${{ steps.labels.outputs.high_stakes != 'true' }}
+        continue-on-error: true
+        uses: qodo-ai/pr-agent@31d7dd027968e5fad1f9cbb074be047c4869058e
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONFIG.MODEL: ${{ steps.cfg.outputs.model }}
+          CONFIG.CUSTOM_MODEL_MAX_TOKENS: "131072"
+          CONFIG.MAX_MODEL_TOKENS: "64000"
+          CONFIG.FALLBACK_MODELS: '["deepseek/deepseek-v4-pro"]'
+          GITHUB_ACTION_CONFIG.PR_ACTIONS: '["opened","reopened","ready_for_review","review_requested","synchronize"]'
+          GITHUB_ACTION_CONFIG.AUTO_REVIEW: "true"
+          GITHUB_ACTION_CONFIG.AUTO_IMPROVE: "false"
+          PR_REVIEWER.REQUIRE_TICKET_ANALYSIS_REVIEW: "false"
+          PR_REVIEWER.REQUIRE_SCORE_REVIEW: "true"
+
+      # ── PR-Agent review (high-stakes) ────────────────────────────────────
+      - name: PR-Agent review (high-stakes)
+        id: review-highstakes
+        if: ${{ steps.labels.outputs.high_stakes == 'true' }}
+        continue-on-error: true
+        uses: qodo-ai/pr-agent@31d7dd027968e5fad1f9cbb074be047c4869058e
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONFIG.MODEL: ${{ steps.cfg.outputs.model }}
+          CONFIG.CUSTOM_MODEL_MAX_TOKENS: "131072"
+          CONFIG.MAX_MODEL_TOKENS: "64000"
+          CONFIG.FALLBACK_MODELS: '["deepseek/deepseek-v4-pro"]'
+          GITHUB_ACTION_CONFIG.PR_ACTIONS: '["opened","reopened","ready_for_review","review_requested","synchronize"]'
+          GITHUB_ACTION_CONFIG.AUTO_REVIEW: "true"
+          GITHUB_ACTION_CONFIG.AUTO_IMPROVE: "false"
+          PR_REVIEWER.REQUIRE_TICKET_ANALYSIS_REVIEW: "false"
+          PR_REVIEWER.REQUIRE_SCORE_REVIEW: "true"
+
+      # ── Score-bracket label ──────────────────────────────────────────────
+      - name: Apply score-bracket label
+        if: |
+          always() &&
+          steps.cfg.outputs.score_labels == 'true' &&
+          (steps.review-default.outcome == 'success' || steps.review-highstakes.outcome == 'success')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUM="${{ github.event.pull_request.number || github.event.issue.number }}"
+          [[ -z "$PR_NUM" || "$PR_NUM" == "null" ]] && { echo "No PR number — skip"; exit 0; }
+
+          gh label create 'score-90+'     --color '0e8a16' --description 'PR-Agent score 90-100 (ship)'              --repo "${{ github.repository }}" 2>/dev/null || true
+          gh label create 'score-80-89'   --color 'fbca04' --description 'PR-Agent score 80-89 (review carefully)'  --repo "${{ github.repository }}" 2>/dev/null || true
+          gh label create 'score-70-79'   --color 'e99695' --description 'PR-Agent score 70-79 (address suggestions)'--repo "${{ github.repository }}" 2>/dev/null || true
+          gh label create 'score-below-70'--color 'b60205' --description 'PR-Agent score <70 (probable blocking issues)'--repo "${{ github.repository }}" 2>/dev/null || true
+
+          LATEST=$(gh api "repos/${{ github.repository }}/issues/$PR_NUM/comments" \
+            --jq '[.[] | select(.user.login=="github-actions[bot]") | .body] | last // ""')
+          SCORE=$(echo "$LATEST" | grep -oE '[Ss]core[^0-9]{0,30}[0-9]+' | grep -oE '[0-9]+' | head -1)
+          [[ -z "$SCORE" ]] && { echo "No score — skip label"; exit 0; }
+          echo "Score: $SCORE"
+
+          for L in 'score-90+' 'score-80-89' 'score-70-79' 'score-below-70'; do
+            gh issue edit "$PR_NUM" --remove-label "$L" --repo "${{ github.repository }}" 2>/dev/null || true
+          done
+
+          if   (( SCORE >= 90 )); then BRACKET='score-90+'
+          elif (( SCORE >= 80 )); then BRACKET='score-80-89'
+          elif (( SCORE >= 70 )); then BRACKET='score-70-79'
+          else                         BRACKET='score-below-70'
+          fi
+          gh issue edit "$PR_NUM" --add-label "$BRACKET" --repo "${{ github.repository }}"
+          echo "Applied: $BRACKET"
+
+      # ── Score banner ─────────────────────────────────────────────────────
+      - name: Inject score banner into PR description
+        if: |
+          always() &&
+          steps.cfg.outputs.score_banner == 'true' &&
+          (steps.review-default.outcome == 'success' || steps.review-highstakes.outcome == 'success')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_USER: ${{ github.event.comment.user.login }}
+          COMMENT_URL: ${{ github.event.comment.html_url }}
+          RUN_ID: ${{ github.run_id }}
+          REPO: ${{ github.repository }}
+          DISPLAY_TZ: ${{ vars.DISPLAY_TZ }}
+          MODEL: ${{ steps.cfg.outputs.model }}
+        run: |
+          PR_NUM="${{ github.event.pull_request.number || github.event.issue.number }}"
+          [[ -z "$PR_NUM" || "$PR_NUM" == "null" ]] && { echo "No PR number — skip"; exit 0; }
+
+          gh api "repos/${REPO}/issues/$PR_NUM/comments" > /tmp/pr-comments.json
+          REVIEW_BODY=$(jq -r '[.[] | select(.user.login=="github-actions[bot]") | select(.body | contains("Reviewer Guide"))] | last.body // ""' /tmp/pr-comments.json)
+          REVIEW_URL=$(jq  -r '[.[] | select(.user.login=="github-actions[bot]") | select(.body | contains("Reviewer Guide"))] | last.html_url // ""' /tmp/pr-comments.json)
+          SCORE=$(printf '%s' "$REVIEW_BODY" | grep -oE '[Ss]core[^0-9]{0,30}[0-9]+' | grep -oE '[0-9]+' | head -1)
+          [[ -z "$SCORE" ]] && { echo "No score — skip banner"; exit 0; }
+
+          if   (( SCORE >= 90 )); then BRACKET='score-90+';    EMOJI='🟢'
+          elif (( SCORE >= 80 )); then BRACKET='score-80-89';  EMOJI='🟡'
+          elif (( SCORE >= 70 )); then BRACKET='score-70-79';  EMOJI='🟠'
+          else                         BRACKET='score-below-70'; EMOJI='🔴'
+          fi
+
+          YES="⚠️ [yes](${REVIEW_URL})"
+          printf '%s' "$REVIEW_BODY" | grep -qi  'No security concerns' && SEC="none ✅"   || SEC="$YES"
+          printf '%s' "$REVIEW_BODY" | grep -qi  'No major issues'      && MAJOR="none ✅" || MAJOR="$YES"
+          printf '%s' "$REVIEW_BODY" | grep -qiE 'Key issues to review' && MINOR="$YES"    || MINOR="none ✅"
+
+          case "$EVENT_NAME" in
+            issue_comment)
+              CMD=$(printf '%s' "$COMMENT_BODY" | grep -oE '^/[a-zA-Z]+' | head -1)
+              [[ -z "$CMD" ]] && CMD='comment'
+              TRIGGER_DESC="\`${CMD}\` by @${COMMENT_USER}"
+              SPECIFIC=" · [comment](${COMMENT_URL})" ;;
+            pull_request|pull_request_target)
+              TRIGGER_DESC="\`pull_request.${EVENT_ACTION}\`"
+              [[ -n "$HEAD_SHA" && "$HEAD_SHA" != "null" ]] \
+                && SPECIFIC=" · [commit ${HEAD_SHA:0:7}](https://github.com/${REPO}/commit/${HEAD_SHA})" \
+                || SPECIFIC="" ;;
+            *) TRIGGER_DESC="\`${EVENT_NAME}\`"; SPECIFIC="" ;;
+          esac
+
+          RUN_URL="https://github.com/${REPO}/actions/runs/${RUN_ID}"
+          NOW_UTC=$(date -u '+%Y-%m-%d %H:%M UTC')
+          if [[ -n "${DISPLAY_TZ:-}" ]]; then
+            NOW_LOCAL=$(TZ="$DISPLAY_TZ" date '+%Y-%m-%d %H:%M %Z')
+            NOW_DISPLAY="${NOW_LOCAL} / ${NOW_UTC}"
+          else
+            NOW_DISPLAY="$NOW_UTC"
+          fi
+          MODEL_SHORT="${MODEL##*/}"
+
+          gh pr view "$PR_NUM" --json body --jq .body --repo "${REPO}" > /tmp/pr-body-current.md
+          sed -i.bak '/<!-- argos-status:start -->/,/<!-- argos-status:end -->/d' /tmp/pr-body-current.md
+          rm -f /tmp/pr-body-current.md.bak
+
+          cat > /tmp/pr-body-banner.md <<EOFBANNER
+<!-- argos-status:start -->
+> ${EMOJI} **PR-Agent Score: ${SCORE}** \`${BRACKET}\` · model: \`${MODEL_SHORT}\`
+> 🔒 **Security:** ${SEC} · ⚡ **Major:** ${MAJOR} · 🔍 **Minor:** ${MINOR}
+> **Triggered by** ${TRIGGER_DESC}${SPECIFIC} · run [#${RUN_ID}](${RUN_URL}) · ${NOW_DISPLAY}
+<!-- argos-status:end -->
+
+EOFBANNER
+
+          cat /tmp/pr-body-banner.md /tmp/pr-body-current.md > /tmp/pr-body-new.md
+          gh pr edit "$PR_NUM" --body-file /tmp/pr-body-new.md --repo "${REPO}"
+          echo "Banner injected (score $SCORE)"
+
+      # ── Commit status check ──────────────────────────────────────────────
+      # Green  = PR-Agent ran and returned a score.
+      # Red    = crashed or returned empty — this is NOT a clean pass.
+      - name: PR-Agent review status check
+        if: always() && steps.cfg.outputs.status_check == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUM="${{ github.event.pull_request.number || github.event.issue.number }}"
+          [[ -z "$PR_NUM" || "$PR_NUM" == "null" ]] && { echo "No PR — skip"; exit 0; }
+
+          SHA="${{ github.event.pull_request.head.sha }}"
+          if [[ -z "$SHA" || "$SHA" == "null" ]]; then
+            SHA=$(gh pr view "$PR_NUM" --repo "${{ github.repository }}" --json headRefOid --jq .headRefOid)
+          fi
+
+          BODY=$(gh api "repos/${{ github.repository }}/issues/$PR_NUM/comments" \
+            --jq '[.[] | select(.user.login=="github-actions[bot]") | select(.body | contains("Reviewer Guide")) | .body] | last // ""')
+          SCORE=$(printf '%s' "$BODY" | grep -oiE 'score[^0-9]{0,20}[0-9]{1,3}' | grep -oE '[0-9]{1,3}' | head -1)
+
+          if [[ -n "$SCORE" ]]; then
+            gh api -X POST "repos/${{ github.repository }}/statuses/$SHA" \
+              -f state=success -f context="pr-agent/review" \
+              -f description="Reviewed — score $SCORE" >/dev/null
+          else
+            gh api -X POST "repos/${{ github.repository }}/statuses/$SHA" \
+              -f state=failure -f context="pr-agent/review" \
+              -f description="No score parsed — review failed or empty (not a clean pass)" >/dev/null
+            gh pr comment "$PR_NUM" --repo "${{ github.repository }}" \
+              --body "> ❌ **PR-Agent produced no score** — it likely crashed or returned an empty review. Re-run with \`/review\`."
+            exit 1
+          fi
+
+
+# ── Local review (claude -p) ─────────────────────────────────────────────────
+#
+# NOT automated in CI — GitHub Actions can't access macOS Keychain, so
+# claude.ai OAuth tokens don't work. Run manually from a terminal:
+#
+#   .agents/scripts/pr-review.sh <PR-number>          # stdout only
+#   .agents/scripts/pr-review.sh <PR-number> --post   # post to PR

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,97 @@
+# .pr_agent.toml — PR-Agent configuration template
+# Part of ai_guidance/pipelines/pr-reviewer/
+#
+# Copy to your project root and customise the extra_instructions section
+# to match your project's skills/, forbidden patterns, and conventions.
+#
+# Docs: https://qodo-merge-docs.qodo.ai/usage-guide/configuration_options/
+
+[config]
+model = "deepseek/deepseek-v4-pro"
+fallback_models = ["deepseek/deepseek-v4-pro"]
+verbosity_level = 1
+max_description_tokens = 1500
+max_commits_tokens = 1500
+custom_model_max_tokens = 131072
+# Raised above the 32K default so full diffs fit without driving the
+# output-token budget negative on large PRs.
+max_model_tokens = 64000
+
+[pr_reviewer]
+require_score_review = true
+require_tests_review = true
+require_security_review = true
+require_focused_review = false
+require_ticket_analysis_review = false
+num_code_suggestions = 4
+inline_code_comments = true
+automatic_review = true
+persistent_comment = true
+final_update_message = false
+extra_instructions = """
+You are the SPEC-ENFORCER for performantlabs.com — a Drupal website with Playwright E2E tests.
+Your job is drift detection, not code improvement.
+
+WHAT THIS PROJECT IS:
+- Drupal website hosted on Pantheon (dev/test/live environments)
+- Playwright E2E tests that run nightly against Pantheon environments
+- Two operating modes: CI mode (fix tests only) and Local mode (fix anything)
+
+MANDATORY CONTEXT — read before scoring:
+1. CLAUDE.md at repo root — operating modes, test healing instructions, forbidden patterns.
+
+PRIMARY JOB — spec drift:
+1. In CI-triggered PRs: does the diff ONLY touch test code? Any website source change (PHP, Twig, JS, CSS) in a CI-originated PR is BLOCKING — the CI runner cannot deploy to Pantheon.
+2. Are secrets committed (API keys, Pantheon tokens, credentials)? = BLOCKING.
+3. Missing Playwright test coverage for new page interactions? = BLOCKING.
+4. Playwright selectors using fragile approaches (XPath, nth-child) when a role/label/text selector is available? = WARN.
+
+SECONDARY JOB — quality:
+- Test flakiness risks (missing waitFor, hardcoded timeouts, shared state between tests).
+- Missing cross-environment compatibility (tests that only work on one Pantheon env).
+
+REVIEW STYLE:
+- Distinguish BLOCKING from NIT.
+- Do not suggest moving test logic into Drupal modules — Playwright tests live in the repo.
+- When in doubt between blocking and nit, prefer nit.
+"""
+
+[pr_code_suggestions]
+num_code_suggestions = 4
+summarize = true
+extra_instructions = """
+Only suggest changes that bring the diff into compliance with skills/*.md or docs/planning/*.md.
+Every suggestion must cite its source (skill filename or spec section).
+Do not suggest refactors or alternative patterns not required by the spec.
+"""
+
+[pr_description]
+publish_description_as_comment = false
+add_original_user_description = true
+keep_original_user_title = true
+
+[github]
+publish_inline_comments = true
+publish_output = true
+publish_output_progress = false
+
+[github_action_config]
+auto_review = true
+auto_improve = false
+pr_actions = ["opened", "reopened", "ready_for_review", "review_requested", "synchronize"]
+
+[litellm]
+drop_params = true
+max_model_len = 131072
+
+[ignore]
+glob = [
+  'package-lock.json',
+  'yarn.lock',
+  'pnpm-lock.yaml',
+  'dist/**',
+  'coverage/**',
+  '*.min.js',
+  '*.min.css',
+  'docs/handoffs/**',
+]


### PR DESCRIPTION
## Summary

- Adds the canonical PR reviewer system from `ai_guidance/pipelines/pr-reviewer/`
- PR-Agent with DeepSeek V4 Pro: spec-enforcer focused on Drupal + Playwright conventions
- Score-bracket labels, score banner in PR description, `pr-agent/review` status check
- DCO sign-off enforcement
- Canonical PR template

## Test plan
- [ ] Open a test PR — PR-Agent should run and post a score
- [ ] Score-bracket label should appear
- [ ] Score banner should inject into PR description

🤖 Generated with Claude Code