### PR TITLE
chore: adopt object:sub-object:verb npm script convention

### DIFF
--- a/local/demo/README-demo.md
+++ b/local/demo/README-demo.md
@@ -131,7 +131,7 @@ npm run demo:reset
 
 ### **Healing Process**
 1. **CTRF Report**: `test:local` generates `ctrf/ctrf-report.json`
-2. **OpenCode Analysis**: `heal:local` reads report and calls OpenCode CLI
+2. **OpenCode Analysis**: `local:heal` reads report and calls OpenCode CLI
 3. **LLM Prompt**: Includes test details, error messages, and Drupal-specific guidance
 4. **Code Extraction**: Parses LLM response for fixed JavaScript code
 5. **Apply Changes**: Updates test file with user confirmation (auto-accept in demo)
@@ -256,5 +256,5 @@ Or run the full diagnostic:
 ```bash
 npm run demo:reset
 npm run demo:setup
-HEAL_AUTO_ACCEPT=true DEBUG_HEAL=true npm run heal:local
+HEAL_AUTO_ACCEPT=true DEBUG_HEAL=true npm run local:heal
 ```

--- a/local/demo/demo-run.js
+++ b/local/demo/demo-run.js
@@ -40,7 +40,7 @@ async function runDemo() {
     
     // Run healing with auto-accept
     process.env.HEAL_AUTO_ACCEPT = 'true';
-    const healProcess = spawn('npm', ['run', 'heal:local'], {
+    const healProcess = spawn('npm', ['run', 'local:heal'], {
       stdio: 'inherit',
       shell: true
     });

--- a/local/heal-local.js
+++ b/local/heal-local.js
@@ -97,7 +97,7 @@ class LocalTestHealer {
     this.logger.error('No local LLM detected. Please install Ollama or configure OpenCode.');
     this.logger.info('Installation: https://ollama.com/download');
     this.logger.info('Recommended model: `ollama pull mfdoom/deepseek-coder-v2-tool-calling:latest`');
-    this.logger.info('Or run: `npm run setup:local-llm`');
+    this.logger.info('Or run: `npm run llm:local:setup`');
     
     return { available: false, provider: null, recommendedModel: null };
   }
@@ -386,7 +386,7 @@ FIXED TEST CODE:
     const llmCheck = await this.checkLocalLLM();
     if (!llmCheck.available) {
       this.logger.error('Cannot proceed without local LLM.');
-      this.logger.info('Run `npm run setup:local-llm` for setup instructions.');
+      this.logger.info('Run `npm run llm:local:setup` for setup instructions.');
       process.exit(1);
     }
     
@@ -408,7 +408,7 @@ FIXED TEST CODE:
       this.logger.info(`Test Summary: ${reportData.passed} passed, ${reportData.failed} failed, ${reportData.skipped} skipped`);
     } catch (error) {
       this.logger.error(error.message);
-      this.logger.info('Run `npm run test:local` first to generate test report.');
+      this.logger.info('Run `npm run test:local` first to generate the test report.');
       process.exit(1);
     }
     

--- a/local/setup-local-llm.js
+++ b/local/setup-local-llm.js
@@ -109,14 +109,14 @@ class LLMSetup {
       console.log('      ollama pull mfdoom/deepseek-coder-v2-tool-calling:latest');
       console.log('   3. Test the healing workflow:');
       console.log('      npm run test:local -- tests/demo-healing.spec.js');
-      console.log('      npm run heal:local');
+      console.log('      npm run local:heal');
     } else {
       console.log('\n❌ Cannot proceed without Ollama.');
       console.log('\n📋 Installation instructions:');
       console.log('   1. Download Ollama: https://ollama.com/download');
       console.log('   2. Install and start: ollama serve');
       console.log('   3. Pull a model: ollama pull mfdoom/deepseek-coder-v2-tool-calling:latest');
-      console.log('   4. Run this setup again: npm run setup:local-llm');
+      console.log('   4. Run this setup again: npm run llm:local:setup');
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
   },
   "scripts": {
     "test:local": "node local/test-local.js",
-    "heal:local": "node local/heal-local.js",
-    "test-and-heal": "npm run test:local && npm run heal:local",
-    "setup:local-llm": "node local/setup-local-llm.js",
+    "local:heal": "node local/heal-local.js",
+    "local:test-heal": "npm run test:local && npm run local:heal",
+    "llm:local:setup": "node local/setup-local-llm.js",
     "demo:setup": "node local/demo/demo-setup.js",
     "demo:run": "node local/demo/demo-run.js",
     "demo:reset": "node local/demo/demo-reset.js",


### PR DESCRIPTION
## Summary

Applies the Performant Labs `object:sub-object:verb` npm script naming convention.

| Old name | New name | Rationale |
|---|---|---|
| `heal:local` | `local:heal` | Object (`local`) first, verb (`heal`) last |
| `test-and-heal` | `local:test-heal` | Hyphens → colons; scope first, compound verb last |
| `setup:local-llm` | `llm:local:setup` | Object (`llm`), qualifier (`local`), verb (`setup`) |
| `test:local` | `test:local` | Kept — bare lifecycle + qualifier is compliant |
| `demo:*` | `demo:*` | Kept — already compliant |

All internal cross-references updated:
- `package.json` — script entries + `local:test-heal` internal call
- `local/heal-local.js` — log messages referencing old names
- `local/setup-local-llm.js` — console output referencing old names
- `local/demo/demo-run.js` — programmatic `spawn('npm', ['run', ...])` call
- `local/demo/README-demo.md` — documentation examples

No append-only history files were modified.

## Test plan

- [ ] `npm run test:local` — verify script still resolves (unchanged name)
- [ ] `npm run local:heal` — verify renamed script resolves
- [ ] `npm run local:test-heal` — verify compound renamed script resolves
- [ ] `npm run llm:local:setup` — verify renamed script resolves
- [ ] `npm run demo:full` — verify demo chain still resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)