### PR TITLE
chore(ci): route all workflows through CI_RUNNER org variable

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -5,7 +5,7 @@ on: workflow_call
 
 jobs:
   copilot-setup-steps:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-to-pantheon-dev.yml
+++ b/.github/workflows/deploy-to-pantheon-dev.yml
@@ -20,7 +20,7 @@ jobs:
       GH_PROJECT_REPONAME: ${{ github.repository }}
       PANTHEON_BRANCH: ${{ format('build-{0}', github.run_attempt) }}
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "For site $PANTHEON_SITE_NAME.$PANTHEON_ENV."

--- a/.github/workflows/heal-tests-claude.yml
+++ b/.github/workflows/heal-tests-claude.yml
@@ -11,7 +11,7 @@ jobs:
   heal-tests:
     # Only run if the issue has the 'auto-heal' label
     if: contains(github.event.issue.labels.*.name, 'auto-heal')
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/test-against-pantheon.yml
+++ b/.github/workflows/test-against-pantheon.yml
@@ -71,7 +71,7 @@ env:
 
 jobs:
   Define-Matrix:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     outputs:
       startTime: ${{ steps.get-output.outputs.startTime }}
       shardIndex: ${{ steps.get-output.outputs.shardIndex }}
@@ -98,7 +98,7 @@ jobs:
       GH_PROJECT_REPONAME: ${{ github.repository }}
       PANTHEON_BRANCH: ${{ format('build-{0}', github.run_attempt) }}
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     steps:
       - run: echo "The job was automatically triggered by a ${{ github.event_name }} event."
       - run: echo "For site $PANTHEON_SITE_NAME.$PANTHEON_ENV."
@@ -172,7 +172,7 @@ jobs:
       - run: echo "🍏 Job's status ${{ job.status }}."
 
   Merge-Blob-Reports:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
     if: ${{ !cancelled() }}
     needs:
       - Define-Matrix


### PR DESCRIPTION
## Summary

- Switch `copilot-setup-steps.yml`, `deploy-to-pantheon-dev.yml`, `heal-tests-claude.yml`, and `test-against-pantheon.yml` from hardcoded `ubuntu-latest` to `${{ vars.CI_RUNNER || 'ubuntu-latest' }}`
- `CI_RUNNER` org variable is currently set to `self-hosted-linux`, so these will run on Uranus until GH-hosted minutes are repurchased
- `deploy-to-pantheon-dev.yml` and `test-against-pantheon.yml` use `setup-php` and Playwright — both install dependencies at runtime so they work on a clean self-hosted runner

## Test plan

- [ ] Verify CI passes on this PR using the Uranus self-hosted runner
- [ ] Confirm a Pantheon deploy triggers on the right runner after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)