### PR TITLE
fix(pr-review): scope cancel-in-progress so comments don't cancel reviews

### DIFF
--- a/.agents/scripts/check-pr-review-readiness.sh
+++ b/.agents/scripts/check-pr-review-readiness.sh
@@ -64,14 +64,14 @@ if [[ "$PR_AGENT_ENABLED" == "true" ]]; then
   if [[ -f ".pr_agent.toml" ]]; then
     echo "${PASS} .pr_agent.toml present"
   else
-    echo "${FAIL} .pr_agent.toml missing — copy from ai_guidance/pipelines/pr-reviewer/templates/"
+    echo "${FAIL} .pr_agent.toml missing — copy from playbook/pipelines/pr-reviewer/templates/"
     ((errors++))
   fi
 
   if [[ -f ".github/workflows/pr-review.yml" ]]; then
     echo "${PASS} .github/workflows/pr-review.yml present"
   else
-    echo "${FAIL} .github/workflows/pr-review.yml missing — copy from ai_guidance/pipelines/pr-reviewer/templates/"
+    echo "${FAIL} .github/workflows/pr-review.yml missing — copy from playbook/pipelines/pr-reviewer/templates/"
     ((errors++))
   fi
 
@@ -93,7 +93,7 @@ if [[ "$LOCAL_ENABLED" == "true" ]]; then
     echo "${FAIL} .agents/scripts/pr-review.sh exists but is not executable (run: chmod +x .agents/scripts/pr-review.sh)"
     ((errors++))
   else
-    echo "${FAIL} .agents/scripts/pr-review.sh missing — copy from ai_guidance/pipelines/pr-reviewer/scripts/"
+    echo "${FAIL} .agents/scripts/pr-review.sh missing — copy from playbook/pipelines/pr-reviewer/scripts/"
     ((errors++))
   fi
 
@@ -127,7 +127,7 @@ if [[ "$LOCAL_ENABLED" == "true" ]]; then
       echo "     Source it from ~/.zshrc if you haven't already."
     else
       echo "${WARN} shell-aliases.sh missing — alias '${SHELL_ALIAS}' not available"
-      echo "     Copy from ai_guidance/pipelines/pr-reviewer/scripts/"
+      echo "     Copy from playbook/pipelines/pr-reviewer/scripts/"
     fi
   fi
 else
@@ -146,7 +146,7 @@ if [[ "$DUAL_ENABLED" == "true" ]]; then
     echo "${FAIL} .agents/scripts/dual-review.sh exists but is not executable"
     ((errors++))
   else
-    echo "${FAIL} .agents/scripts/dual-review.sh missing — copy from ai_guidance/pipelines/pr-reviewer/scripts/"
+    echo "${FAIL} .agents/scripts/dual-review.sh missing — copy from playbook/pipelines/pr-reviewer/scripts/"
     ((errors++))
   fi
 
@@ -180,7 +180,7 @@ if [[ "$DCO_ENABLED" == "true" ]]; then
   if [[ -f ".github/workflows/dco.yml" ]]; then
     echo "${PASS} .github/workflows/dco.yml present"
   else
-    echo "${FAIL} .github/workflows/dco.yml missing — copy from ai_guidance/pipelines/pr-reviewer/templates/"
+    echo "${FAIL} .github/workflows/dco.yml missing — copy from playbook/pipelines/pr-reviewer/templates/"
     ((errors++))
   fi
 fi

--- a/.agents/scripts/setup-pr-review.sh
+++ b/.agents/scripts/setup-pr-review.sh
@@ -13,7 +13,7 @@
 #   GitHub remote present, Playwright in package.json / pyproject.toml
 #
 # After running: copy or symlink the canonical scripts and workflow templates
-# from ai_guidance/pipelines/pr-reviewer/ into this project.
+# from playbook/pipelines/pr-reviewer/ into this project.
 
 set -euo pipefail
 
@@ -372,7 +372,7 @@ ok "Written: .agents/pr-review.yml"
 if [[ -n "$LOCAL_ALIAS" ]]; then
   ALIASES_FILE="${PROJECT_ROOT}/.agents/scripts/shell-aliases.sh"
   TEMPLATE_SRC=""
-  # Find the template relative to this wizard (works from ai_guidance or copied location)
+  # Find the template relative to this wizard (works from playbook or copied location)
   _wizard_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   if [[ -f "${_wizard_dir}/shell-aliases.sh" ]]; then
     TEMPLATE_SRC="${_wizard_dir}/shell-aliases.sh"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -17,5 +17,5 @@ env:
 
 jobs:
   dco:
-    uses: Performant-Labs/ai_guidance/.github/workflows/dco-reusable.yml@main
+    uses: Performant-Labs/playbook/.github/workflows/dco-reusable.yml@main
     secrets: inherit

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -8,14 +8,15 @@ on:
 
 concurrency:
   group: pr-agent-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
+  # never cancel a running review from an issue_comment (every comment, incl. /review, triggers a run)
+  cancel-in-progress: ${{ github.event_name != 'issue_comment' }}
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   pr-review:
-    uses: Performant-Labs/ai_guidance/.github/workflows/pr-review-reusable.yml@main
+    uses: Performant-Labs/playbook/.github/workflows/pr-review-reusable.yml@main
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Problem

The PR-Agent review workflow (`.github/workflows/pr-review.yml`) is a thin caller into the reusable PR-review workflow. It uses:

```yaml
concurrency:
  group: pr-agent-${{ github.event.pull_request.number || github.event.issue.number }}
  cancel-in-progress: true
```

Combined with the `issue_comment: [created]` trigger, **any** comment on a PR — an ordinary reply, a bot/Tugboat "preview ready" comment, or a `/review` posted mid-body — spawns a run in the `pr-agent-<PR#>` group. GitHub evaluates workflow-level `concurrency` / `cancel-in-progress` at **run creation**, *before* any job-level `if`. So with `cancel-in-progress: true` that comment-triggered run **cancels a still-running review**, freezing the PR-Agent score. The slash-command job filter in the reusable workflow runs too late to prevent the cancellation.

## Fix

Scope cancellation to non-comment events:

```diff
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'issue_comment' }}
```

A push (`synchronize`) still cancels a superseded in-flight review (a new commit makes it stale); an `issue_comment` run never cancels — it queues behind the active review and runs after.

## Rollout caveat

For `pull_request` events GitHub runs the workflow **definition from the base branch**, so this fix only takes effect once it is merged to the default branch (`main`). PRs opened before this merges still use the old definition.

## Also: ai_guidance → playbook

The `ai_guidance` repo was renamed to `Performant-Labs/playbook`. This PR updates the `ai_guidance` references in `.github/` and `.agents/` config to `playbook`.

## Out of scope — flagged

`.github/workflows/deploy-to-pantheon-dev.yml:142` has `rm -rf docs/ai_guidance` (a deploy-time local-path cleanup, not a repo reference) — left unchanged to avoid breaking deploy. Also `.pr_agent.toml` and many `docs/**` files reference `ai_guidance` — out of scope (docs).

## Reference

- Performant-Labs/playbook#165 (tracking issue)
- Performant-Labs/playbook#164 (reference fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
