### PR TITLE
chore(docs): bring pl2 pipeline wiring current with restructured playbook

### DIFF
--- a/docs/admin_tools/guidance-align.env
+++ b/docs/admin_tools/guidance-align.env
@@ -4,4 +4,4 @@
 GEMINI_MODEL="gemini-2.0-flash-thinking-exp"
 
 # The location of the canonical ai_guidance repository
-CANONICAL_SOURCE="$HOME/Sites/ai_guidance"
+CANONICAL_SOURCE="$HOME/Projects/playbook"

--- a/docs/admin_tools/guidance-align.sh
+++ b/docs/admin_tools/guidance-align.sh
@@ -18,7 +18,7 @@ if [ -f "$CONFIG_FILE" ]; then
 else
     # Fallback defaults
     GEMINI_MODEL="gemini-2.0-flash-thinking-exp"
-    CANONICAL_SOURCE="$HOME/Sites/ai_guidance"
+    CANONICAL_SOURCE="$HOME/Projects/playbook"
 fi
 
 SOURCE_DIR="$CANONICAL_SOURCE"

--- a/docs/admin_tools/guidance-alignment-protocol.md
+++ b/docs/admin_tools/guidance-alignment-protocol.md
@@ -1,10 +1,16 @@
 # AI Guidance Alignment Protocol
 
+> **⚠️ Largely obsolete (2026-07).** `docs/ai_guidance` is now a **symlink** into the canonical
+> repo (`~/Projects/playbook`), not a vendored subtree — so there is nothing to diff/sync and this
+> bidirectional-alignment tool is a no-op in practice. It's retained (with its source path
+> corrected from the old `~/Sites/ai_guidance` to `~/Projects/playbook`) only for the rare case a
+> project vendors a real `docs/ai_guidance/` copy instead of symlinking. Edit playbook directly.
+
 This protocol defines the standard operating procedure for aligning a project's `docs/ai_guidance` directory with the canonical source of truth, ensuring that local improvements are contributed back to the global standard.
 
 ## 1. Context & Scope
 - **Target**: `docs/ai_guidance/` (or `docs/` if mapped differently) within the current project.
-- **Source of Truth**: `/Users/andreangelantoni/Sites/ai_guidance`
+- **Source of Truth**: `/Users/andreangelantoni/Projects/playbook`
 - **Goal**: Bidirectional alignment. Pull global updates and contribute local improvements upstream.
 
 ## 2. Deterministic Comparison
@@ -38,7 +44,7 @@ Present the findings to the user in a numbered list with bidirectional options:
 ## 5. Execution
 Based on the user's choice:
 - **Pull/Update Local**: Perform a `git subtree pull` or `cp` from Source to Target.
-- **Push/Update Upstream**: Copy changes from Target to Source (`~/Sites/ai_guidance`) and commit them in the source repo.
+- **Push/Update Upstream**: Copy changes from Target to Source (`~/Projects/playbook`) and commit them in the source repo.
 - **Merge**: Use a merge tool or manual editing to combine changes before applying to both/either.
 
 ---

--- a/docs/ai_guidance
+++ b/docs/ai_guidance
@@ -1,1 +1,1 @@
-/Users/andreangelantoni/Sites/ai_guidance
+/Users/andreangelantoni/Projects/playbook

--- a/docs/pl2/agents/README.md
+++ b/docs/pl2/agents/README.md
@@ -15,8 +15,16 @@ wiring has a git safety net.
 | `audit-orchestrator.md` | audit (O-W-O) | O |
 | `website-auditor.md` | audit | W |
 
-They are **thin pointers**: each composes the ai_guidance core role
-(`~/Sites/ai_guidance/pipelines/website-{frontend,audit}/core/roles/…`) + the platform adapter
+> **Pipeline currency (2026-07):** The playbook front-end pipeline gained an optional **U
+> (UI-walkthrough)** phase between T and S (`~/Projects/playbook/pipelines/website-frontend/core/roles/ui-walkthrough.md`,
+> which composes the shared `workflow/ui-walkthrough.md` + `workflow/playwright-ui-walkthrough.md`
+> contracts). It is **not** mirrored here as a pl2 agent because the name would clobber the
+> shared coding-pipeline `~/.claude/agents/ui-walkthrough.md`; adopt it for pl2 under a
+> `pl2-ui-walkthrough` name if/when a U phase is run. The **audit pipeline was extracted** to its
+> own repo — `github.com/Performant-Labs/website-audit` (local `~/Projects/website-audit`) — so the
+> two audit agents point there, not into the playbook.
+
+They are **thin pointers**: each composes the core role (front-end: `~/Projects/playbook/pipelines/website-frontend/core/roles/…`; audit: `~/Projects/website-audit/core/roles/…` — the audit pipeline was extracted to its own repo) + the platform adapter
 (`drupal-canvas-sdc`) + this project's profile (`docs/pl2/frontend-pipeline-profile.md`).
 
 ## Install / sync

--- a/docs/pl2/agents/architecture-reviewer.md
+++ b/docs/pl2/agents/architecture-reviewer.md
@@ -6,14 +6,13 @@ model: sonnet
 permissionMode: bypassPermissions   # ← dangerous mode (no approval prompts)
 ---
 
-You are A (Architecture Reviewer) in the **Website Front-End Pipeline** — distinct from the dual-review /
-tri-review *coding* pipelines. This project (pl2) instantiates the pipeline by composition:
+You are A (Architecture Reviewer) in the **Website Front-End Pipeline** — distinct from the *coding* pipeline (playbook's single test-first workflow). This project (pl2) instantiates the pipeline by composition:
 this file only wires in the platform adapter and the project profile; your full operating
-contract is the platform-agnostic **core role** in the ai_guidance library.
+contract is the platform-agnostic **core role** in the playbook library.
 
 **Read these first — they ARE your instructions; do not act without them:**
-1. Core role:        ~/Sites/ai_guidance/pipelines/website-frontend/core/roles/architecture-reviewer.md
-2. Platform adapter: ~/Sites/ai_guidance/pipelines/website-frontend/adapters/drupal-canvas-sdc.md
+1. Core role:        ~/Projects/playbook/pipelines/website-frontend/core/roles/architecture-reviewer.md
+2. Platform adapter: ~/Projects/playbook/pipelines/website-frontend/adapters/drupal-canvas-sdc.md
 3. Project profile:  docs/pl2/frontend-pipeline-profile.md
 
 The core role's own "Read first" line points to the shared core docs it needs (principles,

--- a/docs/pl2/agents/audit-orchestrator.md
+++ b/docs/pl2/agents/audit-orchestrator.md
@@ -7,15 +7,15 @@ permissionMode: bypassPermissions   # ← dangerous mode (no approval prompts)
 ---
 
 You are O (Orchestrator) in the **Website Audit Pipeline** (O-W-O) — a DISTINCT pipeline from
-the Website Front-End *build* pipeline and from the coding pipelines. This project (pl2)
+the Website Front-End *build* pipeline and from the coding pipeline. This project (pl2)
 instantiates it by composition; your full operating contract is the platform-agnostic **core
-role** in the ai_guidance library.
+role** in the playbook library.
 
 **Read these first — they ARE your instructions; do not act without them:**
-1. Core role:        ~/Sites/ai_guidance/pipelines/website-audit/core/roles/orchestrator.md
-2. Audit flow:       ~/Sites/ai_guidance/pipelines/website-audit/core/audit-flow.md
-3. Scope template:   ~/Sites/ai_guidance/pipelines/website-audit/audit-scope.example.md
-4. Platform adapter: ~/Sites/ai_guidance/pipelines/website-audit/adapters/drupal-canvas-sdc.md
+1. Core role:        ~/Projects/website-audit/core/roles/orchestrator.md
+2. Audit flow:       ~/Projects/website-audit/core/audit-flow.md
+3. Scope template:   ~/Projects/website-audit/audit-scope.example.md
+4. Platform adapter: ~/Projects/website-audit/adapters/drupal-canvas-sdc.md
 5. Project profile:  docs/pl2/frontend-pipeline-profile.md
 
 **Preflight — verify tool deps before scanning (never run a silently-degraded audit).** Check:
@@ -34,11 +34,11 @@ After the run, also confirm `css-scan.json`'s `notes` is empty (no engine silent
 artifact for this run — `audit-scope.md`, `render-config.json`, `css-scan.json`,
 `render-data.json`, the report HTML, `triage.md`, and decomposed `issues/` — goes inside `$RUN`.
 
-**Tools are single-source in ai_guidance** (no copies in this project). Run from the project
+**Tools are single-source in the Website Audit repo (`~/Projects/website-audit`)** (no copies in this project). Run from the project
 root; node tools resolve deps via `NODE_PATH` (see the profile's "Tools" section for exact
 commands):
-- pre-scan: `python3 ~/Sites/ai_guidance/pipelines/website-audit/core/tools/css-scan.py --cwd "$PWD" --root … --injected-prefix=… --out "$RUN/css-scan.json"`
-- render data: `NODE_PATH="$PWD/node_modules" node ~/Sites/ai_guidance/pipelines/website-audit/core/tools/render-inspect.cjs <url> "$RUN/render-config.json" > "$RUN/render-data.json"`
+- pre-scan: `python3 ~/Projects/website-audit/core/tools/css-scan.py --cwd "$PWD" --root … --injected-prefix=… --out "$RUN/css-scan.json"`
+- render data: `NODE_PATH="$PWD/node_modules" node ~/Projects/website-audit/core/tools/render-inspect.cjs <url> "$RUN/render-config.json" > "$RUN/render-data.json"`
 
 Then spawn **W** via the Agent tool (`subagent_type: website-auditor`), passing the scope path
 and (render phase) the render-data path. Render only when static criticals = 0. **Triage W's

--- a/docs/pl2/agents/feature-implementor.md
+++ b/docs/pl2/agents/feature-implementor.md
@@ -6,14 +6,13 @@ model: sonnet
 permissionMode: bypassPermissions   # ← dangerous mode (no approval prompts)
 ---
 
-You are F (Feature Implementor) in the **Website Front-End Pipeline** — distinct from the dual-review /
-tri-review *coding* pipelines. This project (pl2) instantiates the pipeline by composition:
+You are F (Feature Implementor) in the **Website Front-End Pipeline** — distinct from the *coding* pipeline (playbook's single test-first workflow). This project (pl2) instantiates the pipeline by composition:
 this file only wires in the platform adapter and the project profile; your full operating
-contract is the platform-agnostic **core role** in the ai_guidance library.
+contract is the platform-agnostic **core role** in the playbook library.
 
 **Read these first — they ARE your instructions; do not act without them:**
-1. Core role:        ~/Sites/ai_guidance/pipelines/website-frontend/core/roles/feature-implementor.md
-2. Platform adapter: ~/Sites/ai_guidance/pipelines/website-frontend/adapters/drupal-canvas-sdc.md
+1. Core role:        ~/Projects/playbook/pipelines/website-frontend/core/roles/feature-implementor.md
+2. Platform adapter: ~/Projects/playbook/pipelines/website-frontend/adapters/drupal-canvas-sdc.md
 3. Project profile:  docs/pl2/frontend-pipeline-profile.md
 
 The core role's own "Read first" line points to the shared core docs it needs (principles,

--- a/docs/pl2/agents/orchestrator.md
+++ b/docs/pl2/agents/orchestrator.md
@@ -6,14 +6,13 @@ model: sonnet   # family alias — always resolves to the latest Sonnet
 permissionMode: bypassPermissions   # ← dangerous mode (no approval prompts)
 ---
 
-You are O (Orchestrator) in the **Website Front-End Pipeline** — distinct from the dual-review /
-tri-review *coding* pipelines. This project (pl2) instantiates the pipeline by composition:
+You are O (Orchestrator) in the **Website Front-End Pipeline** — distinct from the *coding* pipeline (playbook's single test-first workflow). This project (pl2) instantiates the pipeline by composition:
 this file only wires in the platform adapter and the project profile; your full operating
-contract is the platform-agnostic **core role** in the ai_guidance library.
+contract is the platform-agnostic **core role** in the playbook library.
 
 **Read these first — they ARE your instructions; do not act without them:**
-1. Core role:        ~/Sites/ai_guidance/pipelines/website-frontend/core/roles/orchestrator.md
-2. Platform adapter: ~/Sites/ai_guidance/pipelines/website-frontend/adapters/drupal-canvas-sdc.md
+1. Core role:        ~/Projects/playbook/pipelines/website-frontend/core/roles/orchestrator.md
+2. Platform adapter: ~/Projects/playbook/pipelines/website-frontend/adapters/drupal-canvas-sdc.md
 3. Project profile:  docs/pl2/frontend-pipeline-profile.md
 
 The core role's own "Read first" line points to the shared core docs it needs (principles,

--- a/docs/pl2/agents/spec-auditor.md
+++ b/docs/pl2/agents/spec-auditor.md
@@ -6,14 +6,13 @@ model: opus   # family alias — always resolves to the latest Opus; S stays Opu
 permissionMode: bypassPermissions   # ← dangerous mode (no approval prompts)
 ---
 
-You are S (Spec Auditor) in the **Website Front-End Pipeline** — distinct from the dual-review /
-tri-review *coding* pipelines. This project (pl2) instantiates the pipeline by composition:
+You are S (Spec Auditor) in the **Website Front-End Pipeline** — distinct from the *coding* pipeline (playbook's single test-first workflow). This project (pl2) instantiates the pipeline by composition:
 this file only wires in the platform adapter and the project profile; your full operating
-contract is the platform-agnostic **core role** in the ai_guidance library.
+contract is the platform-agnostic **core role** in the playbook library.
 
 **Read these first — they ARE your instructions; do not act without them:**
-1. Core role:        ~/Sites/ai_guidance/pipelines/website-frontend/core/roles/spec-auditor.md
-2. Platform adapter: ~/Sites/ai_guidance/pipelines/website-frontend/adapters/drupal-canvas-sdc.md
+1. Core role:        ~/Projects/playbook/pipelines/website-frontend/core/roles/spec-auditor.md
+2. Platform adapter: ~/Projects/playbook/pipelines/website-frontend/adapters/drupal-canvas-sdc.md
 3. Project profile:  docs/pl2/frontend-pipeline-profile.md
 
 The core role's own "Read first" line points to the shared core docs it needs (principles,

--- a/docs/pl2/agents/tester.md
+++ b/docs/pl2/agents/tester.md
@@ -6,14 +6,13 @@ model: sonnet
 permissionMode: bypassPermissions   # ← dangerous mode (no approval prompts)
 ---
 
-You are T (Tester) in the **Website Front-End Pipeline** — distinct from the dual-review /
-tri-review *coding* pipelines. This project (pl2) instantiates the pipeline by composition:
+You are T (Tester) in the **Website Front-End Pipeline** — distinct from the *coding* pipeline (playbook's single test-first workflow). This project (pl2) instantiates the pipeline by composition:
 this file only wires in the platform adapter and the project profile; your full operating
-contract is the platform-agnostic **core role** in the ai_guidance library.
+contract is the platform-agnostic **core role** in the playbook library.
 
 **Read these first — they ARE your instructions; do not act without them:**
-1. Core role:        ~/Sites/ai_guidance/pipelines/website-frontend/core/roles/tester.md
-2. Platform adapter: ~/Sites/ai_guidance/pipelines/website-frontend/adapters/drupal-canvas-sdc.md
+1. Core role:        ~/Projects/playbook/pipelines/website-frontend/core/roles/tester.md
+2. Platform adapter: ~/Projects/playbook/pipelines/website-frontend/adapters/drupal-canvas-sdc.md
 3. Project profile:  docs/pl2/frontend-pipeline-profile.md
 
 The core role's own "Read first" line points to the shared core docs it needs (principles,

--- a/docs/pl2/agents/website-auditor.md
+++ b/docs/pl2/agents/website-auditor.md
@@ -9,12 +9,12 @@ permissionMode: bypassPermissions
 You are W (Website Auditor) in the **Website Audit Pipeline** (O-W-O) — a DISTINCT pipeline
 from the Website Front-End *build* pipeline and from the coding pipelines. This project (pl2)
 instantiates it by composition; your full operating contract is the platform-agnostic **core
-role** in the ai_guidance library.
+role** in the playbook library.
 
 **Read these first — they ARE your instructions; do not act without them:**
-1. Core role:        ~/Sites/ai_guidance/pipelines/website-audit/core/roles/website-auditor.md
-2. Audit flow:       ~/Sites/ai_guidance/pipelines/website-audit/core/audit-flow.md
-3. Platform adapter: ~/Sites/ai_guidance/pipelines/website-audit/adapters/drupal-canvas-sdc.md
+1. Core role:        ~/Projects/website-audit/core/roles/website-auditor.md
+2. Audit flow:       ~/Projects/website-audit/core/audit-flow.md
+3. Platform adapter: ~/Projects/website-audit/adapters/drupal-canvas-sdc.md
 4. Project profile:  docs/pl2/frontend-pipeline-profile.md
 
 Use the **adapter** for platform mechanics (layer hierarchy, component model, injected-var

--- a/docs/pl2/audit-ui.config.json
+++ b/docs/pl2/audit-ui.config.json
@@ -10,6 +10,9 @@
   "navSelector": "[data-drupal-selector=\"mobile-nav-button\"]",
   "auditDir": "docs/pl2/handoffs/audits",
   "toolsDir": "~/Sites/ai_guidance/pipelines/website-audit/core/tools",
+  "cookies": [
+    { "name": "Deterrence-Bypass", "value": "1", "domain": "dev-performant-labs-v2.pantheonsite.io", "path": "/" }
+  ],
   "stateInvariants": [
     {
       "surface": "mobile-nav",

--- a/docs/pl2/audit-ui.config.json
+++ b/docs/pl2/audit-ui.config.json
@@ -19,7 +19,17 @@
     }
   ],
   "pages": [
-    ["homepage", "/"],
-    ["articles", "/articles"]
+    ["Homepage (v2)", "/"],
+    ["Services", "/services"],
+    ["How a testing engagement runs", "/how-we-do-it"],
+    ["Open Source Projects", "/open-source-projects"],
+    ["Introduction to ATK", "/page/11"],
+    ["Articles", "/articles-v2"],
+    ["Contact Us", "/contact-us"],
+    ["Automated testing", "/automated-testing"],
+    ["How We Built This Site", "/how-we-built-this-site"],
+    ["About Us", "/about-us"],
+    ["Documentation", "/docs"],
+    ["CTRFHub", "/ctrfhub"]
   ]
 }

--- a/docs/pl2/audit-ui.config.json
+++ b/docs/pl2/audit-ui.config.json
@@ -9,7 +9,7 @@
   "renderThemeVars": ["--theme-surface", "--theme-text-color-loud", "--space-for-fixed-header", "--spacing-component-internal"],
   "navSelector": "[data-drupal-selector=\"mobile-nav-button\"]",
   "auditDir": "docs/pl2/handoffs/audits",
-  "toolsDir": "~/Sites/ai_guidance/pipelines/website-audit/core/tools",
+  "toolsDir": "~/Projects/website-audit/core/tools",
   "cookies": [
     { "name": "Deterrence-Bypass", "value": "1", "domain": "dev-performant-labs-v2.pantheonsite.io", "path": "/" }
   ],

--- a/docs/pl2/audit-ui.config.json
+++ b/docs/pl2/audit-ui.config.json
@@ -2,7 +2,7 @@
   "$comment": "Machine-readable slice of the project profile for the audit UI (serve.py). Copy into the project repo and fill in. The UI runs the deterministic chain from the project dir.",
   "name": "performantlabs.com (canonical)",
   "project": "~/Sites/pl-performantlabs.com",
-  "siteBaseUrl": "https://performant-labs.ddev.site:8493",
+  "siteBaseUrl": "https://dev-performant-labs-v2.pantheonsite.io",
   "roots": ["web/themes/custom/performant_labs_v2", "web/themes/dripyard_themes/neonbyte", "web/themes/dripyard_themes/dripyard_base"],
   "injectedPrefixes": ["--theme-setting-", "--drupal-displace-", "--offset-from-header"],
   "componentAttr": "data-component-id",

--- a/docs/pl2/dripyard-update-workflow.md
+++ b/docs/pl2/dripyard-update-workflow.md
@@ -51,7 +51,7 @@ ddev drush pm:list --type=theme | grep -E 'dripyard|neonbyte'
 ### 5 — Run the audit pipeline (the regression guard)
 ```bash
 # Scan roots = subtheme only (parents are context-only)
-python3 ~/Sites/ai_guidance/pipelines/website-audit/core/tools/css-scan.py \
+python3 ~/Projects/website-audit/core/tools/css-scan.py \
   --cwd "$PWD" \
   --root web/themes/custom/performant_labs_v2 \
   --injected-prefix=--theme-setting- \
@@ -60,7 +60,7 @@ python3 ~/Sites/ai_guidance/pipelines/website-audit/core/tools/css-scan.py \
   --out docs/pl2/handoffs/audits/$(date +%Y%m%d-%H%M%S)-dripyard-<version>/css-scan.json
 ```
 
-Or launch the full UI: `~/Sites/ai_guidance/pipelines/website-audit/ui/auditctl start`
+Or launch the full UI: `~/Projects/website-audit/ui/auditctl start`
 
 Look for new undefined-var or over-reach warnings that the CHANGELOG didn't flag.
 If the CHANGELOG mentioned API changes, verify the subtheme's `libraries-extend` targets

--- a/docs/pl2/frontend-pipeline-profile.md
+++ b/docs/pl2/frontend-pipeline-profile.md
@@ -1,7 +1,7 @@
 # Project Profile — pl2 (performantlabs.com)
 
 > Instance config for the **Website Front-End Pipeline**
-> (`~/Sites/ai_guidance/pipelines/website-frontend/`). The local `~/.claude/agents/*`
+> (`~/Projects/playbook/pipelines/website-frontend/`). The local `~/.claude/agents/*`
 > compose core role + the `drupal-canvas-sdc` adapter + this profile. Distinct from the
 > coding pipelines.
 
@@ -38,20 +38,22 @@
 - **Stateful-surface inventory:** `docs/pl2/stateful-surfaces.md` + `scripts/state-invariants.config.json`
 - **Nav breakpoint:** re-validate W-06 against pristine 1.1.4 (see elevation runbook Stage 5)
 
-## Tools — single-source from ai_guidance (no copies in this project)
+## Tools — single-source from the playbook / website-audit repos (no copies in this project)
 
-Tool engines are **not** copied into this repo; run them from ai_guidance. Node tools resolve
-their deps from this project's `node_modules` via `NODE_PATH`. Run all commands from the
-project root (`~/Sites/pl-performantlabs.com`).
+Tool engines are **not** copied into this repo. **Audit** tools live in the extracted Website
+Audit repo (`~/Projects/website-audit/core/tools/`); **build** tools (axe, state-invariants)
+live in the playbook front-end pipeline (`~/Projects/playbook/pipelines/website-frontend/core/tools/`).
+Node tools resolve their deps from this project's `node_modules` via `NODE_PATH`. Run all
+commands from the project root (`~/Sites/pl-performantlabs.com`).
 
 - **Audit pre-scan (css-scan, pure Python):**
-  `python3 ~/Sites/ai_guidance/pipelines/website-audit/core/tools/css-scan.py --cwd "$PWD" --root web/themes/custom/performant_labs_v2 --injected-prefix=--theme-setting- --injected-prefix=--drupal-displace- --injected-prefix=--offset-from-header --out <run-dir>/css-scan.json`
+  `python3 ~/Projects/website-audit/core/tools/css-scan.py --cwd "$PWD" --root web/themes/custom/performant_labs_v2 --injected-prefix=--theme-setting- --injected-prefix=--drupal-displace- --injected-prefix=--offset-from-header --out <run-dir>/css-scan.json`
 - **Audit render data (render-inspect, node):**
-  `NODE_PATH="$PWD/node_modules" node ~/Sites/ai_guidance/pipelines/website-audit/core/tools/render-inspect.cjs <url> <run-dir>/render-config.json > <run-dir>/render-data.json`
+  `NODE_PATH="$PWD/node_modules" node ~/Projects/website-audit/core/tools/render-inspect.cjs <url> <run-dir>/render-config.json > <run-dir>/render-data.json`
 - **Build T accessibility (axe, node):**
-  `AXE_BASE_URL=<url> NODE_PATH="$PWD/node_modules" node ~/Sites/ai_guidance/pipelines/website-frontend/core/tools/axe-check.cjs / /articles`
+  `AXE_BASE_URL=<url> NODE_PATH="$PWD/node_modules" node ~/Projects/playbook/pipelines/website-frontend/core/tools/axe-check.cjs / /articles`
 - **Build T interaction (state-invariants):**
-  `STATE_INVARIANTS_CONFIG=scripts/state-invariants.config.json npx playwright test ~/Sites/ai_guidance/pipelines/website-frontend/core/tools/state-invariants.spec.js`
+  `STATE_INVARIANTS_CONFIG=scripts/state-invariants.config.json npx playwright test ~/Projects/playbook/pipelines/website-frontend/core/tools/state-invariants.spec.js`
 
 Node deps (`playwright`, `@axe-core/playwright`, `@playwright/test`) stay installed in this
 project's `node_modules` (see `package.json`). `scripts/state-invariants.config.json` is

--- a/docs/pl2/pl-plan--homepage-overhaul.md
+++ b/docs/pl2/pl-plan--homepage-overhaul.md
@@ -14,7 +14,7 @@ This document is a **trackable runbook**. Every phase, commit, and approval chec
 These rules are non-negotiable. They come from `theme-change.md`, `theme-change--workflow.md`, the AI-guided theme generation SOP, `operational-guidance.md`, `color-management.md`, and the `verification-cookbook.md` Tier 2 contrast pattern. Repeating them here so a single read of this file is enough to act safely.
 
 1. **Every CSS change follows the 7-step workflow** at [`theme-change--workflow.md`](theme-change--workflow.md). Trace the variable chain. Override at the highest correct layer. Never override at the point of noticing.
-2. **Every verification follows the Three-Tier Hierarchy.** Tier 1 (`curl`) → Tier 2 (ARIA structural) → Tier 3 (visual). Tier 3 never runs before Tier 2 passes. See [`~/Sites/ai_guidance/testing/verification-cookbook.md`](../../../ai_guidance/testing/verification-cookbook.md).
+2. **Every verification follows the Three-Tier Hierarchy.** Tier 1 (`curl`) → Tier 2 (ARIA structural) → Tier 3 (visual). Tier 3 never runs before Tier 2 passes. See [`~/Projects/playbook/testing/verification-cookbook.md`](../../../ai_guidance/testing/verification-cookbook.md).
 3. **Color overrides use the Layer 4 component-wrapper pattern.** `html .theme--white { --theme-surface: …; }`. Beats Dripyard's inline `<html>` style on specificity. See `Briefs/archive/pl_homepage_components.md` §"How Dripyard's color system actually works."
 4. **Read the `.component.yml` before any prop reference.** Never write a Canvas `component_id`, prop name, slot name, schema value, or entity ID from memory.
 5. **Preserve Canvas `component_version`** in every assembly script — do NOT set to NULL. Canvas throws `OutOfRangeException` on NULL/empty values (discovered Sprint 5 cycle 2, 2026-05-11). For patches: leave the field's existing valid hash untouched. For new components: read the valid hash from the component's `.component.yml` or copy from an existing instance. See `scripts/sprint6-cycle3-nearshore-marker.php` for the idempotent-preserving pattern.
@@ -66,10 +66,10 @@ Every Tier 2 audit confirms: landmark roles (`<header>`, `<main>`, `<footer>`, `
 **Goal:** confirm the environment is ready before any code is written.
 
 **Steps:**
-- [ ] Read [`~/Sites/ai_guidance/frameworks/drupal/theming/ai-guided-theme-generation.md`](../../../ai_guidance/frameworks/drupal/theming/ai-guided-theme-generation.md) Phase 0 in full.
-- [ ] Read [`~/Sites/ai_guidance/frameworks/drupal/theming/operational-guidance.md`](../../../ai_guidance/frameworks/drupal/theming/operational-guidance.md) in full.
-- [ ] Read [`~/Sites/ai_guidance/themes/dripyard-guidance.md`](../../../ai_guidance/themes/dripyard-guidance.md) §1–§9 (Stack, Hierarchy, Color, Typography, Layout, Library, Preprocess, SDC).
-- [ ] Read [`~/Sites/ai_guidance/testing/verification-cookbook.md`](../../../ai_guidance/testing/verification-cookbook.md) §Tier 2 (Skeleton-First) and §"Backdrop Changes — Re-run Contrast" in full.
+- [ ] Read [`~/Projects/playbook/frameworks/drupal/theming/ai-guided-theme-generation.md`](../../../ai_guidance/frameworks/drupal/theming/ai-guided-theme-generation.md) Phase 0 in full.
+- [ ] Read [`~/Projects/playbook/frameworks/drupal/theming/operational-guidance.md`](../../../ai_guidance/frameworks/drupal/theming/operational-guidance.md) in full.
+- [ ] Read [`~/Projects/playbook/themes/dripyard-guidance.md`](../../../ai_guidance/themes/dripyard-guidance.md) §1–§9 (Stack, Hierarchy, Color, Typography, Layout, Library, Preprocess, SDC).
+- [ ] Read [`~/Projects/playbook/testing/verification-cookbook.md`](../../../ai_guidance/testing/verification-cookbook.md) §Tier 2 (Skeleton-First) and §"Backdrop Changes — Re-run Contrast" in full.
 - [ ] Read [`pre-flight-checks.md`](pre-flight-checks.md) and complete every item.
 - [ ] Verify SDC Styleguide module is enabled: `ddev drush pm:list --type=module | grep sdc_styleguide`.
 - [ ] Confirm SDC explorer is reachable: `ddev exec "curl -sk -o /dev/null -w '%{http_code}' https://pl-performantlabs.com.3.ddev.site/styleguide/explorer"` (expect `200` or `403`).

--- a/docs/pl2/pl-plan--pipeline-v2.md
+++ b/docs/pl2/pl-plan--pipeline-v2.md
@@ -2,7 +2,7 @@
 
 **Created:** 2026-06-12
 **Scope:** O-F-A-T-S implementation pipeline + O-W-O audit pipeline
-**Source:** Pipeline review against `~/Sites/ai_guidance` tri-review workflow (2026-06-12)
+**Source:** Pipeline review against `~/Projects/playbook` tri-review workflow (2026-06-12)
 **Posture:** Local-only repo — merge with `--no-ff`, never push, no PRs.
 
 Each stage is independently shippable and leaves the pipeline in a working state.
@@ -59,10 +59,10 @@ Run stages in order; do not start a stage until the prior stage's exit criteria 
 
 ## Stage 2 — Tri-review gates (o3 + Opus 4.8 adversarial reviewers)
 
-**Goal:** Import the ai_guidance tri-review gate. Two outside reviewers on a byte-identical prompt at the two gates; O reconciles.
+**Goal:** Import the playbook tri-review gate (now the review-rigor dial in `pipeline-conventions.md`). Two outside reviewers on a byte-identical prompt at the two gates; O reconciles.
 
-- [x] Verify `~/Sites/ai_guidance/workflow/dual-review.sh` runs here: `OPENAI_API_KEY` available, `--dump-only` and `--prompt-file` flags work against a sample brief.
-- [x] Add gate procedure to orchestrator.md, inherited from `tri-review.md`:
+- [x] Verify `~/Projects/playbook/workflow/dual-review.sh` runs here: `OPENAI_API_KEY` available, `--dump-only` and `--prompt-file` flags work against a sample brief.
+- [x] Add gate procedure to orchestrator.md, inherited from `pipeline-conventions.md` (formerly `tri-review.md`):
   - **Brief gate** (before F): dump canonical prompt → o3 arm via `--prompt-file` → Opus 4.8 arm as fresh **read-only** subagent (mandatory wrapper — the #56 incident) → O reconciles; `hard` findings amend the brief before F spawns.
   - **Diff gate** (after A PASS, before T): same fan-out on the diff prompt; `hard` findings route back to F.
 - [x] Enablement declarations in the brief template (`Tri-review of brief: on|off`, `Tri-review of diff: on|off`). Default **on** for: component-creating stories, shared-token changes, nav/header (high blast radius). Default **off** for: single-file token fixes (W-03-class work).
@@ -102,7 +102,7 @@ Run stages in order; do not start a stage until the prior stage's exit criteria 
 
 ## Stage 4 — Testing depth: stateful surfaces + deterministic a11y
 
-**Goal:** Close finding 5 — the lost-filter bug class. Import the 4-step state invariant from the ai_guidance architecture-audit system into T.
+**Goal:** Close finding 5 — the lost-filter bug class. Import the 4-step state invariant from the playbook architecture-audit system into T.
 
 - [x] Create `docs/pl2/stateful-surfaces.md` — persistent inventory of stateful UI surfaces on shipped pages: filters, pagination, accordion/tab open state, mobile-nav toggle, scroll restoration, search input, theme/language toggles. O updates it whenever a phase ships a new surface.
 - [x] Extend **T** (not a new stage — T already owns structural verification and has browser tooling post-Stage-1) with a **Tier 2.5 interaction suite**: for each inventoried surface the phase touches, run the 4-step invariant via Playwright:

--- a/docs/pl2/pl-plan--sprint-1-conversion-repair.md
+++ b/docs/pl2/pl-plan--sprint-1-conversion-repair.md
@@ -39,13 +39,13 @@ Every visitor-facing path from CTA to contact form must resolve without error. T
 
 All agents follow the standing operating rules from `workflow-ofts.md`. Sprint-specific notes:
 
-- **Three-Tier Verification Hierarchy** (`~/Sites/ai_guidance/testing/verification-cookbook.md`): T runs Tier 1 (curl/grep) + Tier 2 (ARIA/structural). S runs Tier 3 (visual). Tier 1 before Tier 2; Tier 2 before Tier 3. Never open a browser until the structural skeleton passes.
+- **Three-Tier Verification Hierarchy** (`~/Projects/playbook/testing/verification-cookbook.md`): T runs Tier 1 (curl/grep) + Tier 2 (ARIA/structural). S runs Tier 3 (visual). Tier 1 before Tier 2; Tier 2 before Tier 3. Never open a browser until the structural skeleton passes.
 - **7-step CSS change workflow** (`docs/pl2/theme-change--workflow.md`): applies if any CSS is touched (unlikely in this sprint — scope is routes, config, and content).
-- **Operational guidance** (`~/Sites/ai_guidance/frameworks/drupal/theming/operational-guidance.md`): curl first, browser last. Efficiency rules and known failure patterns.
-- **Visual regression strategy** (`~/Sites/ai_guidance/frameworks/drupal/theming/visual-regression-strategy.md`): Tier 3 VR gates are blocking — S must pass before O commits.
+- **Operational guidance** (`~/Projects/playbook/frameworks/drupal/theming/operational-guidance.md`): curl first, browser last. Efficiency rules and known failure patterns.
+- **Visual regression strategy** (`~/Projects/playbook/frameworks/drupal/theming/visual-regression-strategy.md`): Tier 3 VR gates are blocking — S must pass before O commits.
 - **Layer system** (`docs/pl2/theme-change.md`): override at the highest correct layer. L1 (Drupal config) → L3 (tokens) → L5 (component CSS) → L6 (Twig). Never patch at L4.
-- **Dripyard guidance** (`~/Sites/ai_guidance/themes/dripyard-guidance.md`): color architecture, OKLCH, theme wrappers.
-- **Canvas scripting protocol** (`~/Sites/ai_guidance/frameworks/drupal/theming/canvas-scripting-protocol.md`): if any Canvas patches are needed, **preserve `component_version`** — do NOT set to NULL (Canvas throws `OutOfRangeException`; corrected 2026-05-12 by Sprint 10 cycle 2a; see `workflow-ofts.md` §F prompt step 8).
+- **Dripyard guidance** (`~/Projects/playbook/themes/dripyard-guidance.md`): color architecture, OKLCH, theme wrappers.
+- **Canvas scripting protocol** (`~/Projects/playbook/frameworks/drupal/theming/canvas-scripting-protocol.md`): if any Canvas patches are needed, **preserve `component_version`** — do NOT set to NULL (Canvas throws `OutOfRangeException`; corrected 2026-05-12 by Sprint 10 cycle 2a; see `workflow-ofts.md` §F prompt step 8).
 - Read `.component.yml` before referencing any prop name — schema is source of truth.
 - No `!important`. Stage files by explicit path (never `git add .`).
 
@@ -148,11 +148,11 @@ After merge to `main`, delete sprint-1 handoff files. This runbook stays as perm
 | What you need | Where |
 |---|---|
 | O-F-T-S pipeline — agent roles, handoff templates | `docs/pl2/workflow-ofts.md` |
-| Three-Tier Verification Hierarchy (T1/T2/T3) | `~/Sites/ai_guidance/testing/verification-cookbook.md` |
+| Three-Tier Verification Hierarchy (T1/T2/T3) | `~/Projects/playbook/testing/verification-cookbook.md` |
 | 7-step CSS change workflow | `docs/pl2/theme-change--workflow.md` |
 | CSS layer system and override strategy | `docs/pl2/theme-change.md` |
-| Operational guidance (efficiency rules, curl-first) | `~/Sites/ai_guidance/frameworks/drupal/theming/operational-guidance.md` |
-| Visual regression strategy (Tier 3 VR gates) | `~/Sites/ai_guidance/frameworks/drupal/theming/visual-regression-strategy.md` |
-| Dripyard color architecture, OKLCH, theme wrappers | `~/Sites/ai_guidance/themes/dripyard-guidance.md` |
-| Layer 4 component-wrapper override pattern | `~/Sites/ai_guidance/frameworks/drupal/theme-planning/color-management.md` |
-| Canvas scripting protocol | `~/Sites/ai_guidance/frameworks/drupal/theming/canvas-scripting-protocol.md` |
+| Operational guidance (efficiency rules, curl-first) | `~/Projects/playbook/frameworks/drupal/theming/operational-guidance.md` |
+| Visual regression strategy (Tier 3 VR gates) | `~/Projects/playbook/frameworks/drupal/theming/visual-regression-strategy.md` |
+| Dripyard color architecture, OKLCH, theme wrappers | `~/Projects/playbook/themes/dripyard-guidance.md` |
+| Layer 4 component-wrapper override pattern | `~/Projects/playbook/frameworks/drupal/theme-planning/color-management.md` |
+| Canvas scripting protocol | `~/Projects/playbook/frameworks/drupal/theming/canvas-scripting-protocol.md` |

--- a/docs/pl2/pl-plan--sprint-2-mobile-aa-sweep.md
+++ b/docs/pl2/pl-plan--sprint-2-mobile-aa-sweep.md
@@ -41,12 +41,12 @@ Close the four defensive CSS issues that affect mobile usability and WCAG 2.2 AA
 All agents follow the standing operating rules from `workflow-ofts.md`. Sprint-specific emphasis:
 
 - **7-step CSS change workflow** (`docs/pl2/theme-change--workflow.md`): **mandatory for every CSS edit in this sprint.** All four scope items are CSS. Step 3 layer-approval gate is especially critical for item #2 (P14 dark-zone link color) which touches L3 tokens.
-- **Three-Tier Verification Hierarchy** (`~/Sites/ai_guidance/testing/verification-cookbook.md`): T runs Tier 1 + Tier 2. S runs Tier 3. Curl first, browser last. T must pass before S starts.
-- **Operational guidance** (`~/Sites/ai_guidance/frameworks/drupal/theming/operational-guidance.md`): curl-first principle, efficiency rules, known failure patterns. F should read this before starting.
-- **Visual regression strategy** (`~/Sites/ai_guidance/frameworks/drupal/theming/visual-regression-strategy.md`): Tier 3 VR gates are blocking. S compares against current rendered state (no preview HTML for this sprint — regression check only).
+- **Three-Tier Verification Hierarchy** (`~/Projects/playbook/testing/verification-cookbook.md`): T runs Tier 1 + Tier 2. S runs Tier 3. Curl first, browser last. T must pass before S starts.
+- **Operational guidance** (`~/Projects/playbook/frameworks/drupal/theming/operational-guidance.md`): curl-first principle, efficiency rules, known failure patterns. F should read this before starting.
+- **Visual regression strategy** (`~/Projects/playbook/frameworks/drupal/theming/visual-regression-strategy.md`): Tier 3 VR gates are blocking. S compares against current rendered state (no preview HTML for this sprint — regression check only).
 - **Layer system** (`docs/pl2/theme-change.md`): L1 (Drupal config) → L3 (`:root` tokens in `base.css`) → L5 (component CSS via `libraries-extend`) → L6 (Twig). Override at the highest correct layer. Never patch at L4.
-- **Dripyard guidance** (`~/Sites/ai_guidance/themes/dripyard-guidance.md`): color architecture, OKLCH-derived token chains, theme-wrapper specificity patterns. Essential for P14 dark-zone token work.
-- **Color management** (`~/Sites/ai_guidance/frameworks/drupal/theme-planning/color-management.md`): Layer 4 component-wrapper override pattern — `html .theme--dark { --token: value; }` beats Dripyard's inline style on specificity.
+- **Dripyard guidance** (`~/Projects/playbook/themes/dripyard-guidance.md`): color architecture, OKLCH-derived token chains, theme-wrapper specificity patterns. Essential for P14 dark-zone token work.
+- **Color management** (`~/Projects/playbook/frameworks/drupal/theme-planning/color-management.md`): Layer 4 component-wrapper override pattern — `html .theme--dark { --token: value; }` beats Dripyard's inline style on specificity.
 - Read `.component.yml` before referencing any prop name — schema is source of truth.
 - No `!important`. Stage files by explicit path (never `git add .`).
 - **WCAG contrast computation is F's and T's responsibility.** F computes and documents ratios in handoff. T cross-checks independently. Both use hex values from CSS files, not screenshots.
@@ -165,11 +165,11 @@ After merge to `main`, delete sprint-2 handoff files and the `aa/pl-mobile-hero-
 | What you need | Where |
 |---|---|
 | O-F-T-S pipeline — agent roles, handoff templates | `docs/pl2/workflow-ofts.md` |
-| Three-Tier Verification Hierarchy (T1/T2/T3) | `~/Sites/ai_guidance/testing/verification-cookbook.md` |
+| Three-Tier Verification Hierarchy (T1/T2/T3) | `~/Projects/playbook/testing/verification-cookbook.md` |
 | 7-step CSS change workflow (mandatory this sprint) | `docs/pl2/theme-change--workflow.md` |
 | CSS layer system and override strategy | `docs/pl2/theme-change.md` |
-| Operational guidance (curl-first, efficiency rules) | `~/Sites/ai_guidance/frameworks/drupal/theming/operational-guidance.md` |
-| Visual regression strategy (Tier 3 VR gates) | `~/Sites/ai_guidance/frameworks/drupal/theming/visual-regression-strategy.md` |
-| Dripyard color architecture, OKLCH, theme wrappers | `~/Sites/ai_guidance/themes/dripyard-guidance.md` |
-| Layer 4 component-wrapper override pattern | `~/Sites/ai_guidance/frameworks/drupal/theme-planning/color-management.md` |
+| Operational guidance (curl-first, efficiency rules) | `~/Projects/playbook/frameworks/drupal/theming/operational-guidance.md` |
+| Visual regression strategy (Tier 3 VR gates) | `~/Projects/playbook/frameworks/drupal/theming/visual-regression-strategy.md` |
+| Dripyard color architecture, OKLCH, theme wrappers | `~/Projects/playbook/themes/dripyard-guidance.md` |
+| Layer 4 component-wrapper override pattern | `~/Projects/playbook/frameworks/drupal/theme-planning/color-management.md` |
 | Design tokens, typography scale, spacing | `docs/pl2/Briefs/pl_design_brief.md` |

--- a/docs/pl2/pl-plan--sprint-3-footer-sweep.md
+++ b/docs/pl2/pl-plan--sprint-3-footer-sweep.md
@@ -40,12 +40,12 @@ The site footer has accumulated four discrete issues across the homepage and `/s
 
 All agents follow the standing operating rules from `workflow-ofts.md`. Sprint-specific emphasis:
 
-- **Three-Tier Verification Hierarchy** (`~/Sites/ai_guidance/testing/verification-cookbook.md`): T runs Tier 1 + Tier 2. S runs Tier 3. Tier 1 before Tier 2; Tier 2 before Tier 3. Never open a browser until the structural skeleton passes.
+- **Three-Tier Verification Hierarchy** (`~/Projects/playbook/testing/verification-cookbook.md`): T runs Tier 1 + Tier 2. S runs Tier 3. Tier 1 before Tier 2; Tier 2 before Tier 3. Never open a browser until the structural skeleton passes.
 - **7-step CSS change workflow** (`docs/pl2/theme-change--workflow.md`): applies if any CSS is touched. The mobile CTA (P19 option a) would require Twig + possibly CSS; the footer anchor/link fixes are template-only. Step 3 layer trace required for any CSS change.
-- **Operational guidance** (`~/Sites/ai_guidance/frameworks/drupal/theming/operational-guidance.md`): curl first, browser last. Footer link verification is entirely curl-checkable (grep for `href="/contact"` vs `href="/contact-us"`, grep for anchor IDs).
-- **Visual regression strategy** (`~/Sites/ai_guidance/frameworks/drupal/theming/visual-regression-strategy.md`): Tier 3 VR gates are blocking. **Cross-page T3 required** — footer renders on every page, so S must screenshot at least 4 pages at desktop + mobile.
+- **Operational guidance** (`~/Projects/playbook/frameworks/drupal/theming/operational-guidance.md`): curl first, browser last. Footer link verification is entirely curl-checkable (grep for `href="/contact"` vs `href="/contact-us"`, grep for anchor IDs).
+- **Visual regression strategy** (`~/Projects/playbook/frameworks/drupal/theming/visual-regression-strategy.md`): Tier 3 VR gates are blocking. **Cross-page T3 required** — footer renders on every page, so S must screenshot at least 4 pages at desktop + mobile.
 - **Layer system** (`docs/pl2/theme-change.md`): if P19 option (a) is chosen, the Twig override is L6; any supporting CSS is L5. Override at the highest correct layer.
-- **Dripyard guidance** (`~/Sites/ai_guidance/themes/dripyard-guidance.md`): neonbyte responsive structure, mobile panel vs header strip DOM positions — essential context for P19 investigation.
+- **Dripyard guidance** (`~/Projects/playbook/themes/dripyard-guidance.md`): neonbyte responsive structure, mobile panel vs header strip DOM positions — essential context for P19 investigation.
 - Read `.component.yml` before referencing any prop name — schema is source of truth.
 - No `!important`. Stage files by explicit path (never `git add .`).
 
@@ -163,14 +163,14 @@ After merge to `main`, delete sprint-3 handoff files. This runbook stays as perm
 | What you need | Where |
 |---|---|
 | O-F-T-S pipeline — agent roles, handoff templates | `docs/pl2/workflow-ofts.md` |
-| Three-Tier Verification Hierarchy (T1/T2/T3) | `~/Sites/ai_guidance/testing/verification-cookbook.md` |
+| Three-Tier Verification Hierarchy (T1/T2/T3) | `~/Projects/playbook/testing/verification-cookbook.md` |
 | 7-step CSS change workflow | `docs/pl2/theme-change--workflow.md` |
 | CSS layer system and override strategy | `docs/pl2/theme-change.md` |
-| Operational guidance (curl-first, efficiency rules) | `~/Sites/ai_guidance/frameworks/drupal/theming/operational-guidance.md` |
-| Visual regression strategy (Tier 3 VR gates) | `~/Sites/ai_guidance/frameworks/drupal/theming/visual-regression-strategy.md` |
-| Dripyard color architecture, OKLCH, theme wrappers | `~/Sites/ai_guidance/themes/dripyard-guidance.md` |
-| Layer 4 component-wrapper override pattern | `~/Sites/ai_guidance/frameworks/drupal/theme-planning/color-management.md` |
-| Canvas scripting protocol | `~/Sites/ai_guidance/frameworks/drupal/theming/canvas-scripting-protocol.md` |
+| Operational guidance (curl-first, efficiency rules) | `~/Projects/playbook/frameworks/drupal/theming/operational-guidance.md` |
+| Visual regression strategy (Tier 3 VR gates) | `~/Projects/playbook/frameworks/drupal/theming/visual-regression-strategy.md` |
+| Dripyard color architecture, OKLCH, theme wrappers | `~/Projects/playbook/themes/dripyard-guidance.md` |
+| Layer 4 component-wrapper override pattern | `~/Projects/playbook/frameworks/drupal/theme-planning/color-management.md` |
+| Canvas scripting protocol | `~/Projects/playbook/frameworks/drupal/theming/canvas-scripting-protocol.md` |
 | Design tokens, typography scale, spacing | `docs/pl2/Briefs/pl_design_brief.md` |
 
 ---

--- a/docs/pl2/pl-plan--sprint-4-pre-services-foundation.md
+++ b/docs/pl2/pl-plan--sprint-4-pre-services-foundation.md
@@ -356,7 +356,7 @@ After Cycle 5 (or Cycle 6 if opened) merges:
 - [`Briefs/archive/pl_homepage_components.md`](Briefs/archive/pl_homepage_components.md) — historical component mapping from the homepage overhaul; archived 2026-05-11. Useful as the pattern reference when authoring per-page component briefs for Services / About / etc.
 - [`GET-BACK-TO-THESE.md`](GET-BACK-TO-THESE.md) — full triage of deferred items (the source of Cycles 2–5).
 - [`post-homepage-next.md`](post-homepage-next.md) — the post-ship priority document (the source of Cycles 1 and 6).
-- `~/Sites/ai_guidance/workflow/workflow-ofts-generic.md` — generic O-F-T-S template (canonical upstream of `workflow-ofts.md`).
-- `~/Sites/ai_guidance/testing/verification-cookbook.md` — T1 / T2 / T3 hierarchy.
-- `~/Sites/ai_guidance/frameworks/drupal/theming/operational-guidance.md` — curl-first, browser-last efficiency rules.
-- `~/Sites/ai_guidance/frameworks/drupal/theming/visual-regression-strategy.md` — T3 protocol; mandatory Playwright + ImageMagick visual diff.
+- `~/Projects/playbook/workflow/workflow-coding-pipeline.md` — generic O-F-T-S template (canonical upstream of `workflow-ofts.md`).
+- `~/Projects/playbook/testing/verification-cookbook.md` — T1 / T2 / T3 hierarchy.
+- `~/Projects/playbook/frameworks/drupal/theming/operational-guidance.md` — curl-first, browser-last efficiency rules.
+- `~/Projects/playbook/frameworks/drupal/theming/visual-regression-strategy.md` — T3 protocol; mandatory Playwright + ImageMagick visual diff.

--- a/docs/pl2/post-homepage-next.md
+++ b/docs/pl2/post-homepage-next.md
@@ -268,8 +268,8 @@ Ordered by likely impact on future work. Original state-doc numbering is shown i
 |---------------|-------|
 | 7-step CSS change workflow (mandatory for every CSS edit) | `docs/pl2/theme-change--workflow.md` |
 | CSS layer system and override strategy | `docs/pl2/theme-change.md` |
-| Tier 1 / Tier 2 / Tier 3 verification hierarchy | `~/Sites/ai_guidance/testing/verification-cookbook.md` |
-| Dripyard color architecture, OKLCH, theme wrappers | `~/Sites/ai_guidance/themes/dripyard-guidance.md` |
-| Layer 4 component-wrapper override pattern | `~/Sites/ai_guidance/frameworks/drupal/theme-planning/color-management.md` |
-| Efficiency rules, known failure patterns, browser-call cost | `~/Sites/ai_guidance/frameworks/drupal/theming/operational-guidance.md` |
-| Canvas scripting protocol (drush scr assembly) | `~/Sites/ai_guidance/frameworks/drupal/theming/canvas-scripting-protocol.md` |
+| Tier 1 / Tier 2 / Tier 3 verification hierarchy | `~/Projects/playbook/testing/verification-cookbook.md` |
+| Dripyard color architecture, OKLCH, theme wrappers | `~/Projects/playbook/themes/dripyard-guidance.md` |
+| Layer 4 component-wrapper override pattern | `~/Projects/playbook/frameworks/drupal/theme-planning/color-management.md` |
+| Efficiency rules, known failure patterns, browser-call cost | `~/Projects/playbook/frameworks/drupal/theming/operational-guidance.md` |
+| Canvas scripting protocol (drush scr assembly) | `~/Projects/playbook/frameworks/drupal/theming/canvas-scripting-protocol.md` |

--- a/docs/pl2/theme-change.md
+++ b/docs/pl2/theme-change.md
@@ -441,7 +441,7 @@ html .theme--black {
 
 ---
 
-*Sources: Drupal.org theming docs, CSS-Tricks cascade layers guide, Lullabot `@layer` integration, direct inspection of `dripyard_base` source, prior live-run failure patterns in `docs/ai_guidance/operational-guidance.md`.*
+*Sources: Drupal.org theming docs, CSS-Tricks cascade layers guide, Lullabot `@layer` integration, direct inspection of `dripyard_base` source, prior live-run failure patterns in `docs/ai_guidance/frameworks/drupal/theming/operational-guidance.md`.*
 
 ---
 

--- a/docs/pl2/workflow-ofts.md
+++ b/docs/pl2/workflow-ofts.md
@@ -1,5 +1,16 @@
 # O-F-A-T-S Workflow — Multi-Agent Homepage Overhaul
 
+> **⚠️ Superseded / historical (2026-07).** This document describes the pl2 homepage-overhaul's
+> five-agent O-F-A-T-S cycle as it ran. The playbook's generic *coding* work now uses a single
+> test-first pipeline — [`~/Projects/playbook/workflow/workflow-coding-pipeline.md`](../ai_guidance/workflow/workflow-coding-pipeline.md)
+> (shared primitives in [`pipeline-conventions.md`](../ai_guidance/workflow/pipeline-conventions.md)) —
+> with review-rigor as a per-story dial (none / second-opinion / panel) instead of separate
+> dual/tri-review pipelines, plus a conditional Designer (D) phase. The pl2 **website** pipeline
+> (this doc's O-F-A-T-S) remains its own thing; its live role wiring is in
+> [`agents/`](agents/README.md), and the front-end pipeline additionally offers an optional
+> U (UI-walkthrough) phase (see `agents/README.md`). Read this doc for how the overhaul executed;
+> read the playbook for the current canonical workflow.
+
 > **Parent:** [`pl-plan--homepage-overhaul.md`](pl-plan--homepage-overhaul.md)
 > **Purpose:** defines the five-agent pipeline that executes the homepage overhaul phases. Each phase (or sub-phase) becomes one cycle through the pipeline. The Orchestrator drives the pipeline by spawning F/A/T/S subagents itself; the human operator's role depends on the active mode — at kickoff and on hard-stop-floor events in autonomous mode (default), or at every 🛑 checkpoint in human-in-the-loop mode.
 
@@ -259,9 +270,9 @@ falling back, and why.
 - `docs/pl2/pl-plan--homepage-overhaul.md` — the runbook (your primary doc)
 - `docs/pl2/workflow-ofts.md` — this workflow spec
 - `docs/pl2/handoffs/` — handoff documents from F, A, T, and S
-- `~/Sites/ai_guidance/workflow/workflow-ofats-generic.md` — full O-F-A-T-S workflow spec
-- `~/Sites/ai_guidance/workflow/auditarchitecture.md` — standalone architecture-audit workflow (O → A → O)
-- `~/Sites/ai_guidance/workflow/workflow-website-audit.md` — website CSS/HTML hierarchy audit workflow (O → W → O)
+- `~/Projects/playbook/workflow/workflow-coding-pipeline.md` — full O-F-A-T-S workflow spec
+- `~/Projects/playbook/workflow/auditarchitecture.md` — standalone architecture-audit workflow (O → A → O)
+- `~/Projects/playbook/workflow/workflow-website-audit.md` — website CSS/HTML hierarchy audit workflow (O → W → O)
 ```
 
 ---
@@ -450,11 +461,11 @@ T and O will use to scope their review]
 - `docs/pl2/Briefs/pl_design_brief.md` — visual tokens and design rules
 - `docs/pl2/Briefs/archive/pl_homepage_components.md` — component mapping
 - `docs/pl2/pl-plan--homepage-overhaul.md` — the runbook
-- `~/Sites/ai_guidance/themes/dripyard-guidance.md` — Dripyard system overview
-- `~/Sites/ai_guidance/frameworks/drupal/theme-planning/color-management.md` —
+- `~/Projects/playbook/themes/dripyard-guidance.md` — Dripyard system overview
+- `~/Projects/playbook/frameworks/drupal/theme-planning/color-management.md` —
   Layer 4 override pattern
-- `~/Sites/ai_guidance/testing/verification-cookbook.md` — T1/T2/T3 hierarchy
-- `~/Sites/ai_guidance/frameworks/drupal/theming/operational-guidance.md` —
+- `~/Projects/playbook/testing/verification-cookbook.md` — T1/T2/T3 hierarchy
+- `~/Projects/playbook/frameworks/drupal/theming/operational-guidance.md` —
   efficiency rules and known failure patterns
 ```
 
@@ -484,7 +495,7 @@ Write handoff to: docs/pl2/handoffs/phase-[N]-[slug]-A.md
 
 For the full A agent prompt (review dimensions, handoff template, audit mode,
 standalone audit workflow) see `~/.claude/agents/architecture-reviewer.md` and
-`~/Sites/ai_guidance/workflow/architecture-reviewer.md`.
+`~/Projects/playbook/workflow/architecture-reviewer.md`.
 
 ---
 
@@ -616,7 +627,7 @@ in this phase" if none.]
 
 ## Key references
 
-- `~/Sites/ai_guidance/testing/verification-cookbook.md` — T1/T2/T3 hierarchy
+- `~/Projects/playbook/testing/verification-cookbook.md` — T1/T2/T3 hierarchy
   (your primary reference)
 - `docs/pl2/Briefs/pl_design_brief.md` — color tokens for contrast computation
 - `docs/pl2/Briefs/archive/pl_homepage_components.md` — component mapping
@@ -941,8 +952,8 @@ paused pending operator decision.
 - `docs/pl2/Briefs/archive/pl_homepage_components.md` — component mapping
 - `docs/pl2/Previews/homepage.html` — the static reference render
 - `docs/pl2/pl-plan--homepage-overhaul.md` — acceptance criteria source
-- `~/Sites/ai_guidance/testing/verification-cookbook.md` — T3 protocol
-- `~/Sites/ai_guidance/frameworks/drupal/theming/visual-regression-strategy.md`
+- `~/Projects/playbook/testing/verification-cookbook.md` — T3 protocol
+- `~/Projects/playbook/frameworks/drupal/theming/visual-regression-strategy.md`
   — visual comparison protocol
 ```
 
@@ -978,9 +989,9 @@ Report path: docs/pl2/handoffs/audits/[audit-id]/website-audit-[slug]-[phase].ht
 For the full W agent prompt (all telltale-sign dimensions, render phase protocol,
 HTML report structure, project-specific Dripyard checks) see
 `~/.claude/agents/website-auditor.md` and
-`~/Sites/ai_guidance/workflow/website-auditor.md`.
+`~/Projects/playbook/workflow/website-auditor.md`.
 
-The pipeline spec lives at `~/Sites/ai_guidance/workflow/workflow-website-audit.md`.
+The pipeline spec lives at `~/Projects/playbook/workflow/workflow-website-audit.md`.
 
 ---
 


### PR DESCRIPTION
## Summary

The shared **playbook** repo changed in two independent ways since the last sync, breaking pl2's pipeline references. This PR brings the project current.

1. **Repo relocation** — `~/Sites/ai_guidance` no longer exists (canonical repo is `~/Projects/playbook`). The `docs/ai_guidance` symlink was **dangling**, so every relative `../ai_guidance/…` link and absolute `~/Sites/ai_guidance/…` reference was broken.
2. **Restructuring** — the **Website Audit** pipeline was extracted to its own repo (`github.com/Performant-Labs/website-audit`, local `~/Projects/website-audit`); the `ofats`/`ofts`/`tri-review` workflow trio was retired for a single test-first **coding pipeline** + a **review-rigor dial**; the front-end pipeline gained an optional **U (UI-walkthrough)** phase.

## What changed

| Area | Fix |
|------|-----|
| `docs/ai_guidance` symlink | Repointed → `~/Projects/playbook` (heals all relative doc links; name kept so `.github` cleanup + markdown links stay valid) |
| Audit agents + `audit-ui.config.json` + profile tool cmds | → `~/Projects/website-audit/core/**` (extracted repo) |
| Frontend agents (5) | Absolute paths → `~/Projects/playbook`; dropped stale "dual-review / tri-review coding pipelines" clause |
| Retired workflow refs | `workflow-ofats-*` / `ofts-generic` / `tri-review.md` → `workflow-coding-pipeline.md` / `pipeline-conventions.md` |
| `workflow-ofts.md` | Superseded/historical banner → current pipeline |
| `agents/README.md` | Fixed core-role wording, noted audit extraction + new optional U phase |
| `admin_tools/guidance-align.*` | Repointed dead canonical source; marked obsolete (symlink model now) |
| `~/.claude/agents/*.md` | Re-synced; **all Read-first targets verified to resolve** |

## Verification

- Every agent thin-pointer's core-role / adapter / tool target resolves (checked on disk).
- All cited theming/testing markdown links resolve through the repointed symlink.
- No `~/Sites/ai_guidance`, retired-workflow, or `playbook/pipelines/website-audit` mis-paths remain in active docs.
- Historical `handoffs/` + `Briefs/` intentionally left as point-in-time records (symlink heals their links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)