### PR TITLE
chore(docs): finish playbook currency — audit extraction + pipeline wording

### DIFF
--- a/docs/admin_tools/guidance-align.env
+++ b/docs/admin_tools/guidance-align.env
@@ -4,4 +4,4 @@
 GEMINI_MODEL="gemini-2.0-flash-thinking-exp"
 
 # The location of the canonical ai_guidance repository
-CANONICAL_SOURCE="$HOME/Sites/ai_guidance"
+CANONICAL_SOURCE="$HOME/Projects/playbook"

--- a/docs/admin_tools/guidance-align.sh
+++ b/docs/admin_tools/guidance-align.sh
@@ -18,7 +18,7 @@ if [ -f "$CONFIG_FILE" ]; then
 else
     # Fallback defaults
     GEMINI_MODEL="gemini-2.0-flash-thinking-exp"
-    CANONICAL_SOURCE="$HOME/Sites/ai_guidance"
+    CANONICAL_SOURCE="$HOME/Projects/playbook"
 fi
 
 SOURCE_DIR="$CANONICAL_SOURCE"

--- a/docs/admin_tools/guidance-alignment-protocol.md
+++ b/docs/admin_tools/guidance-alignment-protocol.md
@@ -1,6 +1,11 @@
 # AI Guidance Alignment Protocol
 
-This protocol defines the standard operating procedure for aligning a project's `docs/ai_guidance` directory with the canonical source of truth, ensuring that local improvements are contributed back to the global standard.
+> **⚠️ Largely obsolete (2026-07).** `docs/playbook` is now a **symlink** into the canonical repo
+> (`~/Projects/playbook`), not a vendored subtree — so there is nothing to diff/sync and this
+> bidirectional-alignment tool is a no-op in practice. Its source path was corrected from the old
+> `~/Sites/ai_guidance` to `~/Projects/playbook`; edit the playbook repo directly.
+
+This protocol defines the standard operating procedure for aligning a project's `docs/playbook` directory with the canonical source of truth, ensuring that local improvements are contributed back to the global standard.
 
 ## 1. Context & Scope
 - **Target**: `docs/ai_guidance/` (or `docs/` if mapped differently) within the current project.

--- a/docs/pl2/agents/README.md
+++ b/docs/pl2/agents/README.md
@@ -15,8 +15,15 @@ wiring has a git safety net.
 | `audit-orchestrator.md` | audit (O-W-O) | O |
 | `website-auditor.md` | audit | W |
 
-They are **thin pointers**: each composes the playbook core role
-(`~/Projects/playbook/pipelines/website-{frontend,audit}/core/roles/…`) + the platform adapter
+> **Pipeline currency (2026-07):** The **audit pipeline was extracted** to its own repo —
+> `github.com/Performant-Labs/website-audit` (local `~/Projects/website-audit`) — so the two audit
+> agents point there, not into the playbook. The playbook front-end pipeline also gained an optional
+> **U (UI-walkthrough)** phase between T and S
+> (`~/Projects/playbook/pipelines/website-frontend/core/roles/ui-walkthrough.md`); it is **not**
+> mirrored here because the name would clobber the shared coding-pipeline `~/.claude/agents/ui-walkthrough.md`
+> — adopt it under a `pl2-ui-walkthrough` name if/when a U phase is run.
+
+They are **thin pointers**: each composes the core role (front-end: `~/Projects/playbook/pipelines/website-frontend/core/roles/…`; audit: `~/Projects/website-audit/core/roles/…`) + the platform adapter
 (`drupal-canvas-sdc`) + this project's profile (`docs/pl2/frontend-pipeline-profile.md`).
 
 ## Install / sync

--- a/docs/pl2/agents/architecture-reviewer.md
+++ b/docs/pl2/agents/architecture-reviewer.md
@@ -6,8 +6,7 @@ model: sonnet
 permissionMode: bypassPermissions   # ← dangerous mode (no approval prompts)
 ---
 
-You are A (Architecture Reviewer) in the **Website Front-End Pipeline** — distinct from the dual-review /
-tri-review *coding* pipelines. This project (pl2) instantiates the pipeline by composition:
+You are A (Architecture Reviewer) in the **Website Front-End Pipeline** — distinct from the *coding* pipeline (playbook's single test-first workflow). This project (pl2) instantiates the pipeline by composition:
 this file only wires in the platform adapter and the project profile; your full operating
 contract is the platform-agnostic **core role** in the playbook library.
 

--- a/docs/pl2/agents/audit-orchestrator.md
+++ b/docs/pl2/agents/audit-orchestrator.md
@@ -12,10 +12,10 @@ instantiates it by composition; your full operating contract is the platform-agn
 role** in the playbook library.
 
 **Read these first — they ARE your instructions; do not act without them:**
-1. Core role:        ~/Projects/playbook/pipelines/website-audit/core/roles/orchestrator.md
-2. Audit flow:       ~/Projects/playbook/pipelines/website-audit/core/audit-flow.md
-3. Scope template:   ~/Projects/playbook/pipelines/website-audit/audit-scope.example.md
-4. Platform adapter: ~/Projects/playbook/pipelines/website-audit/adapters/drupal-canvas-sdc.md
+1. Core role:        ~/Projects/website-audit/core/roles/orchestrator.md
+2. Audit flow:       ~/Projects/website-audit/core/audit-flow.md
+3. Scope template:   ~/Projects/website-audit/audit-scope.example.md
+4. Platform adapter: ~/Projects/website-audit/adapters/drupal-canvas-sdc.md
 5. Project profile:  docs/pl2/frontend-pipeline-profile.md
 
 **Preflight — verify tool deps before scanning (never run a silently-degraded audit).** Check:
@@ -34,11 +34,11 @@ After the run, also confirm `css-scan.json`'s `notes` is empty (no engine silent
 artifact for this run — `audit-scope.md`, `render-config.json`, `css-scan.json`,
 `render-data.json`, the report HTML, `triage.md`, and decomposed `issues/` — goes inside `$RUN`.
 
-**Tools are single-source in playbook** (no copies in this project). Run from the project
+**Tools are single-source in the Website Audit repo (`~/Projects/website-audit`)** (no copies in this project). Run from the project
 root; node tools resolve deps via `NODE_PATH` (see the profile's "Tools" section for exact
 commands):
-- pre-scan: `python3 ~/Projects/playbook/pipelines/website-audit/core/tools/css-scan.py --cwd "$PWD" --root … --injected-prefix=… --out "$RUN/css-scan.json"`
-- render data: `NODE_PATH="$PWD/node_modules" node ~/Projects/playbook/pipelines/website-audit/core/tools/render-inspect.cjs <url> "$RUN/render-config.json" > "$RUN/render-data.json"`
+- pre-scan: `python3 ~/Projects/website-audit/core/tools/css-scan.py --cwd "$PWD" --root … --injected-prefix=… --out "$RUN/css-scan.json"`
+- render data: `NODE_PATH="$PWD/node_modules" node ~/Projects/website-audit/core/tools/render-inspect.cjs <url> "$RUN/render-config.json" > "$RUN/render-data.json"`
 
 Then spawn **W** via the Agent tool (`subagent_type: website-auditor`), passing the scope path
 and (render phase) the render-data path. Render only when static criticals = 0. **Triage W's

--- a/docs/pl2/agents/feature-implementor.md
+++ b/docs/pl2/agents/feature-implementor.md
@@ -6,8 +6,7 @@ model: sonnet
 permissionMode: bypassPermissions   # ← dangerous mode (no approval prompts)
 ---
 
-You are F (Feature Implementor) in the **Website Front-End Pipeline** — distinct from the dual-review /
-tri-review *coding* pipelines. This project (pl2) instantiates the pipeline by composition:
+You are F (Feature Implementor) in the **Website Front-End Pipeline** — distinct from the *coding* pipeline (playbook's single test-first workflow). This project (pl2) instantiates the pipeline by composition:
 this file only wires in the platform adapter and the project profile; your full operating
 contract is the platform-agnostic **core role** in the playbook library.
 

--- a/docs/pl2/agents/orchestrator.md
+++ b/docs/pl2/agents/orchestrator.md
@@ -6,8 +6,7 @@ model: sonnet   # family alias — always resolves to the latest Sonnet
 permissionMode: bypassPermissions   # ← dangerous mode (no approval prompts)
 ---
 
-You are O (Orchestrator) in the **Website Front-End Pipeline** — distinct from the dual-review /
-tri-review *coding* pipelines. This project (pl2) instantiates the pipeline by composition:
+You are O (Orchestrator) in the **Website Front-End Pipeline** — distinct from the *coding* pipeline (playbook's single test-first workflow). This project (pl2) instantiates the pipeline by composition:
 this file only wires in the platform adapter and the project profile; your full operating
 contract is the platform-agnostic **core role** in the playbook library.
 

--- a/docs/pl2/agents/spec-auditor.md
+++ b/docs/pl2/agents/spec-auditor.md
@@ -6,8 +6,7 @@ model: opus   # family alias — always resolves to the latest Opus; S stays Opu
 permissionMode: bypassPermissions   # ← dangerous mode (no approval prompts)
 ---
 
-You are S (Spec Auditor) in the **Website Front-End Pipeline** — distinct from the dual-review /
-tri-review *coding* pipelines. This project (pl2) instantiates the pipeline by composition:
+You are S (Spec Auditor) in the **Website Front-End Pipeline** — distinct from the *coding* pipeline (playbook's single test-first workflow). This project (pl2) instantiates the pipeline by composition:
 this file only wires in the platform adapter and the project profile; your full operating
 contract is the platform-agnostic **core role** in the playbook library.
 

--- a/docs/pl2/agents/tester.md
+++ b/docs/pl2/agents/tester.md
@@ -6,8 +6,7 @@ model: sonnet
 permissionMode: bypassPermissions   # ← dangerous mode (no approval prompts)
 ---
 
-You are T (Tester) in the **Website Front-End Pipeline** — distinct from the dual-review /
-tri-review *coding* pipelines. This project (pl2) instantiates the pipeline by composition:
+You are T (Tester) in the **Website Front-End Pipeline** — distinct from the *coding* pipeline (playbook's single test-first workflow). This project (pl2) instantiates the pipeline by composition:
 this file only wires in the platform adapter and the project profile; your full operating
 contract is the platform-agnostic **core role** in the playbook library.
 

--- a/docs/pl2/agents/website-auditor.md
+++ b/docs/pl2/agents/website-auditor.md
@@ -12,9 +12,9 @@ instantiates it by composition; your full operating contract is the platform-agn
 role** in the playbook library.
 
 **Read these first — they ARE your instructions; do not act without them:**
-1. Core role:        ~/Projects/playbook/pipelines/website-audit/core/roles/website-auditor.md
-2. Audit flow:       ~/Projects/playbook/pipelines/website-audit/core/audit-flow.md
-3. Platform adapter: ~/Projects/playbook/pipelines/website-audit/adapters/drupal-canvas-sdc.md
+1. Core role:        ~/Projects/website-audit/core/roles/website-auditor.md
+2. Audit flow:       ~/Projects/website-audit/core/audit-flow.md
+3. Platform adapter: ~/Projects/website-audit/adapters/drupal-canvas-sdc.md
 4. Project profile:  docs/pl2/frontend-pipeline-profile.md
 
 Use the **adapter** for platform mechanics (layer hierarchy, component model, injected-var

--- a/docs/pl2/audit-ui.config.json
+++ b/docs/pl2/audit-ui.config.json
@@ -9,7 +9,7 @@
   "renderThemeVars": ["--theme-surface", "--theme-text-color-loud", "--space-for-fixed-header", "--spacing-component-internal"],
   "navSelector": "[data-drupal-selector=\"mobile-nav-button\"]",
   "auditDir": "docs/pl2/handoffs/audits",
-  "toolsDir": "~/Sites/ai_guidance/pipelines/website-audit/core/tools",
+  "toolsDir": "~/Projects/website-audit/core/tools",
   "cookies": [
     { "name": "Deterrence-Bypass", "value": "1", "domain": "dev-performant-labs-v2.pantheonsite.io", "path": "/" }
   ],

--- a/docs/pl2/dripyard-update-workflow.md
+++ b/docs/pl2/dripyard-update-workflow.md
@@ -51,7 +51,7 @@ ddev drush pm:list --type=theme | grep -E 'dripyard|neonbyte'
 ### 5 — Run the audit pipeline (the regression guard)
 ```bash
 # Scan roots = subtheme only (parents are context-only)
-python3 ~/Projects/playbook/pipelines/website-audit/core/tools/css-scan.py \
+python3 ~/Projects/website-audit/core/tools/css-scan.py \
   --cwd "$PWD" \
   --root web/themes/custom/performant_labs_v2 \
   --injected-prefix=--theme-setting- \
@@ -60,7 +60,7 @@ python3 ~/Projects/playbook/pipelines/website-audit/core/tools/css-scan.py \
   --out docs/pl2/handoffs/audits/$(date +%Y%m%d-%H%M%S)-dripyard-<version>/css-scan.json
 ```
 
-Or launch the full UI: `~/Projects/playbook/pipelines/website-audit/ui/auditctl start`
+Or launch the full UI: `~/Projects/website-audit/ui/auditctl start`
 
 Look for new undefined-var or over-reach warnings that the CHANGELOG didn't flag.
 If the CHANGELOG mentioned API changes, verify the subtheme's `libraries-extend` targets

--- a/docs/pl2/frontend-pipeline-profile.md
+++ b/docs/pl2/frontend-pipeline-profile.md
@@ -38,16 +38,19 @@
 - **Stateful-surface inventory:** `docs/pl2/stateful-surfaces.md` + `scripts/state-invariants.config.json`
 - **Nav breakpoint:** re-validate W-06 against pristine 1.1.4 (see elevation runbook Stage 5)
 
-## Tools — single-source from playbook (no copies in this project)
+## Tools — single-source from the playbook / website-audit repos (no copies in this project)
 
-Tool engines are **not** copied into this repo; run them from playbook. Node tools resolve
+Tool engines are **not** copied into this repo. **Audit** tools live in the extracted Website
+Audit repo (`~/Projects/website-audit/core/tools/`); **build** tools (axe, state-invariants) live
+in the playbook front-end pipeline (`~/Projects/playbook/pipelines/website-frontend/core/tools/`).
+Node tools resolve
 their deps from this project's `node_modules` via `NODE_PATH`. Run all commands from the
 project root (`~/Sites/pl-performantlabs.com`).
 
 - **Audit pre-scan (css-scan, pure Python):**
-  `python3 ~/Projects/playbook/pipelines/website-audit/core/tools/css-scan.py --cwd "$PWD" --root web/themes/custom/performant_labs_v2 --injected-prefix=--theme-setting- --injected-prefix=--drupal-displace- --injected-prefix=--offset-from-header --out <run-dir>/css-scan.json`
+  `python3 ~/Projects/website-audit/core/tools/css-scan.py --cwd "$PWD" --root web/themes/custom/performant_labs_v2 --injected-prefix=--theme-setting- --injected-prefix=--drupal-displace- --injected-prefix=--offset-from-header --out <run-dir>/css-scan.json`
 - **Audit render data (render-inspect, node):**
-  `NODE_PATH="$PWD/node_modules" node ~/Projects/playbook/pipelines/website-audit/core/tools/render-inspect.cjs <url> <run-dir>/render-config.json > <run-dir>/render-data.json`
+  `NODE_PATH="$PWD/node_modules" node ~/Projects/website-audit/core/tools/render-inspect.cjs <url> <run-dir>/render-config.json > <run-dir>/render-data.json`
 - **Build T accessibility (axe, node):**
   `AXE_BASE_URL=<url> NODE_PATH="$PWD/node_modules" node ~/Projects/playbook/pipelines/website-frontend/core/tools/axe-check.cjs / /articles`
 - **Build T interaction (state-invariants):**

--- a/docs/pl2/pl-plan--sprint-4-pre-services-foundation.md
+++ b/docs/pl2/pl-plan--sprint-4-pre-services-foundation.md
@@ -356,7 +356,7 @@ After Cycle 5 (or Cycle 6 if opened) merges:
 - [`Briefs/archive/pl_homepage_components.md`](Briefs/archive/pl_homepage_components.md) — historical component mapping from the homepage overhaul; archived 2026-05-11. Useful as the pattern reference when authoring per-page component briefs for Services / About / etc.
 - [`GET-BACK-TO-THESE.md`](GET-BACK-TO-THESE.md) — full triage of deferred items (the source of Cycles 2–5).
 - [`post-homepage-next.md`](post-homepage-next.md) — the post-ship priority document (the source of Cycles 1 and 6).
-- `~/Projects/playbook/workflow/workflow-ofts-generic.md` — generic O-F-T-S template (canonical upstream of `workflow-ofts.md`).
+- `~/Projects/playbook/workflow/workflow-coding-pipeline.md` — generic O-F-T-S template (canonical upstream of `workflow-ofts.md`).
 - `~/Projects/playbook/testing/verification-cookbook.md` — T1 / T2 / T3 hierarchy.
 - `~/Projects/playbook/frameworks/drupal/theming/operational-guidance.md` — curl-first, browser-last efficiency rules.
 - `~/Projects/playbook/frameworks/drupal/theming/visual-regression-strategy.md` — T3 protocol; mandatory Playwright + ImageMagick visual diff.

--- a/docs/pl2/workflow-ofts.md
+++ b/docs/pl2/workflow-ofts.md
@@ -1,5 +1,16 @@
 # O-F-A-T-S Workflow — Multi-Agent Homepage Overhaul
 
+> **⚠️ Superseded / historical (2026-07).** This document describes the pl2 homepage-overhaul's
+> five-agent O-F-A-T-S cycle as it ran. The playbook's generic *coding* work now uses a single
+> test-first pipeline — [`~/Projects/playbook/workflow/workflow-coding-pipeline.md`](../playbook/workflow/workflow-coding-pipeline.md)
+> (shared primitives in [`pipeline-conventions.md`](../playbook/workflow/pipeline-conventions.md)) —
+> with review-rigor as a per-story dial (none / second-opinion / panel) instead of separate
+> dual/tri-review pipelines, plus a conditional Designer (D) phase. The pl2 **website** pipeline
+> (this doc's O-F-A-T-S) remains its own thing; its live role wiring is in
+> [`agents/`](agents/README.md), and the front-end pipeline additionally offers an optional
+> U (UI-walkthrough) phase (see `agents/README.md`). Read this doc for how the overhaul executed;
+> read the playbook for the current canonical workflow.
+
 > **Parent:** [`pl-plan--homepage-overhaul.md`](pl-plan--homepage-overhaul.md)
 > **Purpose:** defines the five-agent pipeline that executes the homepage overhaul phases. Each phase (or sub-phase) becomes one cycle through the pipeline. The Orchestrator drives the pipeline by spawning F/A/T/S subagents itself; the human operator's role depends on the active mode — at kickoff and on hard-stop-floor events in autonomous mode (default), or at every 🛑 checkpoint in human-in-the-loop mode.
 
@@ -259,7 +270,7 @@ falling back, and why.
 - `docs/pl2/pl-plan--homepage-overhaul.md` — the runbook (your primary doc)
 - `docs/pl2/workflow-ofts.md` — this workflow spec
 - `docs/pl2/handoffs/` — handoff documents from F, A, T, and S
-- `~/Projects/playbook/workflow/workflow-ofats-generic.md` — full O-F-A-T-S workflow spec
+- `~/Projects/playbook/workflow/workflow-coding-pipeline.md` — current single coding-pipeline spec (superseded the retired `workflow-ofats-generic.md`)
 - `~/Projects/playbook/workflow/auditarchitecture.md` — standalone architecture-audit workflow (O → A → O)
 - `~/Projects/playbook/workflow/workflow-website-audit.md` — website CSS/HTML hierarchy audit workflow (O → W → O)
 ```


### PR DESCRIPTION
## Summary

Follow-up to #256 (which renamed `ai_guidance → playbook` via the `docs/playbook` symlink). #256 predated **two newer playbook changes**, which this PR applies so pl2's pipeline wiring is fully current. Built cleanly on top of current `main` — no symlink-strategy conflict.

## What #256 left undone

1. **Audit pipeline was extracted** to its own repo (`github.com/Performant-Labs/website-audit`, local `~/Projects/website-audit`). On `main`, the two audit agents still point at the now-dead `~/Projects/playbook/pipelines/website-audit/core/**`.
2. **The ofats/ofts/tri-review workflow trio was retired** for a single test-first coding pipeline + review-rigor dial. Front-end agents still carried the stale "dual-review / tri-review coding pipelines" wording.

## Changes

| Area | Fix |
|------|-----|
| Audit agents + `audit-ui.config.json` + `dripyard-update-workflow` + profile tool cmds | → `~/Projects/website-audit/core/**` |
| Front-end agents (5) | Dropped stale "dual-review / tri-review" clause → single coding pipeline |
| `sprint-4` + `workflow-ofts.md` refs | Retired `workflow-ofats-generic.md` → `workflow-coding-pipeline.md` |
| `workflow-ofts.md` | Superseded/historical banner |
| `agents/README.md` | Audit-extraction note + optional U-phase note + core-role wording |
| `guidance-align.*` | Fixed residual `~/Sites/ai_guidance` #256 missed; marked obsolete |

## Verification

- **All 7 agent thin-pointers' Read-first targets verified to resolve on disk** (front-end → playbook, audit → extracted repo).
- No dead `playbook/pipelines/website-audit`, `~/Sites/ai_guidance`, dual-review, or retired-workflow references remain in active docs.
- Synced to `~/.claude/agents/`.

## Note

**Supersedes #258**, which solved the same newer-change delta but on a divergent `docs/ai_guidance` symlink strategy that conflicts with #256's `docs/playbook`. Closing #258 in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)