### PR TITLE
fix(deploy): prune stale exported config before Pantheon copy

### DIFF
--- a/.github/workflows/deploy-to-pantheon-dev.yml
+++ b/.github/workflows/deploy-to-pantheon-dev.yml
@@ -159,6 +159,16 @@ jobs:
           rm -rf "$PANTHEON_REPO_DIR"/web/profiles/contrib
           rm -rf "$PANTHEON_REPO_DIR"/vendor
 
+          # Remove stale exported config from the Pantheon repo before copying.
+          # config/default/sync is fully source-controlled, but cp -R only
+          # adds/overwrites and never deletes. Config files removed from source
+          # (e.g. between Drupal 11.3 -> 11.4, or when a module is dropped from the
+          # build) otherwise persist in Pantheon's git and make post-deploy
+          # config:import fail (fatal on absent-module config, or "unexpected"
+          # deletions). Clearing the dir lets the cp below rebuild it to exactly
+          # match source, so config:import stays clean.
+          rm -rf "$PANTHEON_REPO_DIR"/config/default/sync
+
           # Copy files to Pantheon repo dir.
           cp -R * "$PANTHEON_REPO_DIR"
 


### PR DESCRIPTION
## Root cause

The **(Deploy) Deploy artifact to Pantheon Dev** workflow assembles the build into a clone of Pantheon's git repo and copies with `cp -R *`, which only adds/overwrites — it never deletes files that were removed from source. The workflow already prunes `web/core`, `web/modules/contrib`, `web/themes/contrib`, `web/profiles/contrib`, and `vendor` for exactly this reason, but **not** `config/default/sync`.

As a result, exported-config files deleted from source persist in Pantheon's repo and break the post-deploy `config:import`:

- `config/default/sync/migrate_plus.migration_group.pl_work_log.yml` — **fatal**: the `migrate_plus` module is absent from the build.
- `config/default/sync/field.field.node.book.layout_builder__layout.yml` — stale.

The local site and `origin/main` are clean (`config:status` = no differences); only Pantheon's git carried the residue.

## Fix

Add one prune line — `rm -rf "$PANTHEON_REPO_DIR"/config/default/sync` — immediately before the `cp -R *`, mirroring the existing core/contrib/vendor prune style. `config/default/sync` is fully source-controlled, so `cp -R *` rebuilds it to exactly match source. Targeted to config sync only; no aggressive whole-tree `--delete` that could touch Pantheon-preserved files.

## Impact

- Unblocks `config:import` on **Dev** (the 7 legit 11.3→11.4 config deltas can then apply cleanly).
- Protects **Test/Live** from hitting the same stale-config residue on their next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)