### PR TITLE
fix(deploy): enable config_ignore before post-deploy config:import (sequencing guard for #289)

### DIFF
--- a/private/scripts/quicksilver/post_deploy.php
+++ b/private/scripts/quicksilver/post_deploy.php
@@ -11,6 +11,13 @@
 echo "=== Post-deploy: Running database updates ===\n";
 passthru('drush updatedb --yes 2>&1');
 
+// Self-heal: config_ignore must be enabled BEFORE config:import runs, or the
+// import will propose deleting the canvas.component.* entities it is meant to
+// ignore (they are DB-owned and intentionally absent from config sync — see
+// PR #289). Idempotent: no-op when already enabled.
+echo "\n=== Post-deploy: Ensuring config_ignore is enabled ===\n";
+passthru('drush pm:install config_ignore --yes 2>&1');
+
 echo "\n=== Post-deploy: Importing configuration ===\n";
 passthru('drush config:import --yes 2>&1');
 


### PR DESCRIPTION
One-line quicksilver guard from the canvas-config diagnosis: `config_ignore` must be enabled **before** `config:import` runs, or the first Test/Live import after #289 would propose deleting all 101 DB-owned `canvas.component.*` entities. `pm:install` is idempotent — no-op everywhere it's already enabled. Tugboat red = pre-existing (#275).

🤖 Generated with [Claude Code](https://claude.com/claude-code)