### PR TITLE
fix(e2e): match both 'Log in' and 'Login' in the login helper

### DIFF
--- a/tests/support/atk_commands.js
+++ b/tests/support/atk_commands.js
@@ -619,7 +619,12 @@ async function logInViaForm(page, context, account) {
   await page.goto(ensureLeadingSlash(atkConfig.logInUrl))
   await page.getByLabel('Username').fill(account.userName)
   await page.getByLabel('Password').fill(account.userPassword)
-  await page.getByRole('button', { name: 'Log in' }).click()
+  // Matches both spellings of the submit button: vanilla Drupal renders
+  // "Log in", while the dripyard_base theme's input--submit override renders
+  // the raw #value, giving "Login". An exact-string locator for either one
+  // silently stops matching when the theme changes — which is what broke the
+  // nightly run for a week (issue #308).
+  await page.getByRole('button', { name: /log\s*in/i }).click()
 
   await page.waitForLoadState('domcontentloaded')
   await expect(page.getByText('Member for')).toBeVisible()


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟢 **PR-Agent Score: 95** `score-90+` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** none ✅ · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit 1fd8ae6](https://github.com/Performant-Labs/performantlabs.com/commit/1fd8ae621ffe1487b23301dd0f8e3dcdd788aa64) · run [#30960309175](https://github.com/Performant-Labs/performantlabs.com/actions/runs/30960309175) · 2026-08-04 17:33 MDT / 2026-08-04 23:33 UTC
<!-- argos-status:end -->

### **User description**
Fixes the 19-of-20 nightly Playwright failures described in #308.

## The bug

`tests/support/atk_commands.js:622` looked for a button named exactly `Log in`:

```js
await page.getByRole('button', { name: 'Log in' }).click()
```

`dripyard_base`'s `templates/form/input--submit.html.twig` renders the raw `#value`, so the live button reads **`Login`** — one word. The locator matched nothing, and every test that authenticates died on a 60-second timeout.

**Timing is exact:** last green run 2026-07-26T00:17Z; the V2 theme reached Pantheon 2026-07-26T22:49Z; first red run four minutes later.

## The fix

A case-insensitive regex matching both spellings.

This is not merely tolerating today's markup. `atk_commands.js` is shared **Automated Testing Kit** code, and **vanilla Drupal renders `Log in`** — so an exact match for *either* spelling is wrong for half its consumers. The regex is correct for both.

## Verified against the live site, with a check that can fail

Ran a real Chromium against `https://performantlabs.com/user/login`:

| locator | matches |
|---|---|
| old, exact `Log in` | **0** |
| new, `/log\s*in/i` | **1** — resolved text `"Login"` |
| `getByLabel('Username')` | 1 |
| `getByLabel('Password')` | 1 |

The old locator resolving 0 reproduces the failure; the new one resolving exactly 1 shows the fix. The form is otherwise intact.

**No strict-mode ambiguity:** exactly one button on that page matches `/log\s*in/i` — the search form's button reads `Search`. Worth noting the page has *two* elements with `id="edit-submit"` (search and login), so an id-based selector would have been ambiguous. The accessible name is the right handle here.

## Not addressed here

The other three problems in #308 are separate and left alone deliberately:

- `atk_contact_us.spec.js:90` — the 20th failure, a missing contact-form confirmation. Different cause.
- **`HttpError: Bad credentials`** in the failure-issue-filing step — the reason a week of red nights filed no tickets. Arguably more important than this fix: it is why nobody knew.
- `getaddrinfo ENOTFOUND reportportal.performantlabs.com` — results uploading nowhere.

Refs #308


___

### **PR Type**
Bug fix


___

### **Description**
- Update `logInViaForm` button locator to a case-insensitive regex `/log\s*in/i` to match both "Log in" (vanilla Drupal) and "Login" (dripyard_base theme).

- Add comment explaining the theme‑dependent rendering of the login button value.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old locator: 'Log in'"] -- "change to" --> B["New locator: /log\\s*in/i"]
  B -- "matches" --> C["Vanilla Drupal: 'Log in'"]
  B -- "matches" --> D["Dripyard theme: 'Login'"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>atk_commands.js</strong><dd><code>Use regex for login button to support multiple renderings</code></dd></summary>
<hr>

tests/support/atk_commands.js

<ul><li>Replace exact string <code>'Log in'</code> role selector with the case‑insensitive <br>regex <code>/log\s*in/i</code>.<br> <li> Add inline documentation explaining why the regex is necessary (theme <br>differences between vanilla Drupal and dripyard_base).</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/performantlabs.com/pull/309/files#diff-af03e2d45a385cef46e8c0b0fb24366b759a3cd5d920f79fc0148dff9c1250bc">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


