### PR TITLE
fix(reporting): probe results services before use; none available is valid

### DIFF
--- a/.github/workflows/test-against-pantheon.yml
+++ b/.github/workflows/test-against-pantheon.yml
@@ -215,12 +215,34 @@ jobs:
           path: ctrf/
           retention-days: 30
 
+      # Result uploads are best-effort. A results service being down is a
+      # reporting gap, not a test failure, and it is valid for none of them to
+      # respond. Each step gates itself and exits 0 when its target is absent,
+      # so this job's status keeps meaning "did the tests pass".
       - name: Upload results to Allure
+        if: ${{ always() && contains(env.ATK_REPORT_TARGET, 'allure') }}
         run: |
+          # The script does its own reachability check and exits 0 when the
+          # server is unset or unreachable.
           ./allure_send_results.sh
 
       - name: Upload results to Testiny
+        if: ${{ always() && contains(env.ATK_REPORT_TARGET, 'testiny') }}
         run: |
+          set -uo pipefail
+          if [ -z "${TESTINY_API_KEY:-}" ]; then
+            echo "[testiny] TESTINY_API_KEY is not set — skipping upload."
+            exit 0
+          fi
+          if [ ! -f playwright-report.json ]; then
+            echo "[testiny] playwright-report.json was not produced — nothing to upload."
+            exit 0
+          fi
+          TESTINY_HOST="${TESTINY_API_HOST:-https://app.testiny.io}"
+          if ! curl -sS -o /dev/null --connect-timeout 5 --max-time 10 "$TESTINY_HOST" 2>/dev/null; then
+            echo "[testiny] $TESTINY_HOST unreachable — skipping upload (not a test failure)."
+            exit 0
+          fi
           npx @testiny/cli automation --project ATK --source Playwright --playwright playwright-report.json --field-values "pantheon_env=${{ env.PANTHEON_ENV }}"
 
       - name: Set environment for messaging results

--- a/allure_send_results.sh
+++ b/allure_send_results.sh
@@ -28,10 +28,33 @@ PROJECT_ID='performantlabs'
 SECURITY_USER=$ALLURE_SECURITY_USER  #'my_username'
 SECURITY_PASS=$ALLURE_SECURITY_PASS  #'my_password'
 
+# Reachability gate.
+#
+# An unavailable results server must not fail the build. The tests already
+# ran; losing an upload is a reporting gap, not a test failure. It is valid
+# for none of the results services to be up.
+#
+# Not hypothetical: reportportal.performantlabs.com was decommissioned and
+# every nightly run errored on it for weeks before anyone noticed (see #308).
+if [ -z "$ALLURE_SERVER" ]; then
+  echo "[allure] ALLURE_SERVER is not set — skipping upload."
+  exit 0
+fi
+# --connect-timeout bounds DNS + TCP. Any HTTP response means something is
+# listening, which is all this needs to establish; credentials are verified
+# by the login call further down.
+if ! curl -sS -o /dev/null --connect-timeout 5 --max-time 10 "$ALLURE_SERVER" 2>/dev/null; then
+  echo "[allure] $ALLURE_SERVER unreachable — skipping upload (not a test failure)."
+  exit 0
+fi
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 FILES_TO_SEND=$(ls -dp $DIR/$ALLURE_RESULTS_DIRECTORY/* | grep -v /$)
 if [ -z "$FILES_TO_SEND" ]; then
-  exit 1
+  # Previously exit 1, which failed the job for a condition the top of this
+  # same script already treats as normal ("does not exist" -> exit 0).
+  echo "[allure] no result files in $ALLURE_RESULTS_DIRECTORY — nothing to upload."
+  exit 0
 fi
 
 FILES=''

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -10,28 +10,66 @@ import { defineConfig, devices } from '@playwright/test'
 import rpconfig from './reportportal.config.js'
 
 /**
- * Check if ReportPortal is available
- * @return {Promise<boolean>} true if it is, false if it's not
+ * Probe a remote results service before wiring up a reporter that talks to it.
+ *
+ * Returns false for anything that is not a usable service right now: DNS
+ * failure, connection refused, TLS error, timeout, or a 5xx. It never throws
+ * and never rejects — an unreachable results service must not be able to fail
+ * a test run. A 4xx counts as reachable: something is listening, and auth is
+ * the uploader's problem, not this probe's.
+ *
+ * @param {string} rawUrl  Any URL on the service.
+ * @param {number} timeout Milliseconds before giving up. Short on purpose —
+ *                         this runs before every non-sharded suite.
+ * @return {Promise<boolean>}
  */
-async function checkReportPortal() {
-  return new Promise((resolve) => {
-    const rpURL = new URL(rpconfig.endpoint)
-    fetch(`${rpURL.protocol}//${rpURL.host}/health`)
-      .then(() => resolve(true))
-      .catch(() => resolve(false))
-  })
+async function isReachable(rawUrl, timeout = 5000) {
+  let url
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    return false // not a URL — treat as "not configured"
+  }
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeout)
+  try {
+    const res = await fetch(url, { signal: controller.signal, redirect: 'follow' })
+    return res.status < 500
+  } catch {
+    return false // DNS / refused / TLS / timeout
+  } finally {
+    clearTimeout(timer)
+  }
 }
 
-// ReportPortal & Allure config
-const reporterMap = {
+/**
+ * Targets whose reporter talks to a REMOTE service DURING the run. These must
+ * be probed first, because the agent starts POSTing as soon as tests begin.
+ */
+const remoteReporters = {
+  reportportal: {
+    probeUrl: () => {
+      const u = new URL(rpconfig.endpoint)
+      return `${u.protocol}//${u.host}/health`
+    },
+    reporter: ['@reportportal/agent-js-playwright', rpconfig],
+  },
+}
+
+/**
+ * Targets whose reporter only writes files locally. Always safe to enable:
+ * the network hop happens in a later CI step (allure_send_results.sh for
+ * Allure, `npx @testiny/cli` for Testiny), and each of those does its own
+ * reachability check. Probing here would gate the wrong thing — the local
+ * artefact is worth producing even when its upload target is gone.
+ */
+const localReporters = {
   allure: ['allure-playwright'],
-  reportportal: ['@reportportal/agent-js-playwright', rpconfig],
   testiny: ['json', { outputFile: 'playwright-report.json' }],
 }
 
-// Define reporters depending on sharding and Portal's availability
+// Base reporters: always on, never network-dependent.
 const reporter = [['list']]
-// const reporter = [];
 const isShard = process.argv.find((arg) => arg.startsWith('--shard'))
 if (isShard) {
   reporter.push(['blob'])
@@ -42,14 +80,31 @@ if (isShard) {
     buildNumber: process.env.BUILD_NUMBER || 'BUILD_NUMBER is not set',
     buildUrl: process.env.BUILD_URL || 'BUILD_URL is not set',
   }])
-  const alltarget = process.env.ATK_REPORT_TARGET
-  if (alltarget) {
-    for (const target of alltarget.split(',')) {
-      if (target in reporterMap) {
-        reporter.push(reporterMap[target])
+
+  // ATK_REPORT_TARGET is a wish list, not a guarantee. Remote targets are
+  // probed and skipped with a reason when down. ZERO reachable targets is a
+  // VALID, non-failing outcome — results still land in the list, HTML and
+  // CTRF reporters, plus any local artefact reporters requested.
+  const requested = (process.env.ATK_REPORT_TARGET || '')
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean)
+
+  for (const target of requested) {
+    if (target in remoteReporters) {
+      const { probeUrl, reporter: rep } = remoteReporters[target]
+      const url = probeUrl()
+      if (await isReachable(url)) {
+        reporter.push(rep)
+        console.log(`[reporting] ${target}: reachable — enabled`)
       } else {
-        console.warn(`Bad report target: ${target}`)
+        console.warn(`[reporting] ${target}: SKIPPED — ${url} unreachable`)
       }
+    } else if (target in localReporters) {
+      reporter.push(localReporters[target])
+      console.log(`[reporting] ${target}: enabled (writes locally; upload is a later step)`)
+    } else {
+      console.warn(`[reporting] unknown target "${target}" — ignored`)
     }
   }
 }


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟢 **PR-Agent Score: 93** `score-90+` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** none ✅ · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit 099cbad](https://github.com/Performant-Labs/performantlabs.com/commit/099cbad2895658ecfde43aa25b22214c9047cc61) · run [#30961299057](https://github.com/Performant-Labs/performantlabs.com/actions/runs/30961299057) · 2026-08-04 17:52 MDT / 2026-08-04 23:52 UTC
<!-- argos-status:end -->

### **User description**
Makes result reporting fail-soft across all three targets, and fixes a gate that was written but never wired up.

Groundwork for replacing these with Aftersight: adding a fourth target is now one entry in one table, and it inherits the reachability behaviour automatically.

## The problem

`reportportal.performantlabs.com` was decommissioned. It is `NXDOMAIN` today, while its siblings (`allure-api.performantlabs.com`, `performantlabs.com`) resolve fine. Every nightly `Merge-Blob-Reports` job has errored on it for weeks — noise in a log nobody reads, because the failure-issue-filing step is *also* broken (#308).

`playwright.config.js` already contained the fix:

```js
async function checkReportPortal() { … }   // ← nothing called it
```

The comment above the reporter block still read *"Define reporters depending on sharding and Portal's availability"*. The availability half was never implemented — the loop added `reportportal` unconditionally whenever it appeared in `ATK_REPORT_TARGET`. Someone anticipated exactly this failure, wrote the guard, and left it dead.

## The three targets are not the same shape

A single "check the domain" in the Playwright config would have gated the wrong thing for two of them:

| target | when it touches the network | gated in |
|---|---|---|
| **reportportal** | **during** the run — the agent POSTs to `…/api/v1` continuously | `playwright.config.js` |
| **allure** | after — reporter writes local `allure-results/`, then `allure_send_results.sh` curls `$ALLURE_SERVER` | the shell script |
| **testiny** | after — reporter writes a local JSON file, then `npx @testiny/cli` uploads | the workflow step |

So the local-artefact reporters stay unconditional. Their artefact is worth producing even when the upload target is gone; only the *upload* is gated.

## What changed

**`playwright.config.js`** — generalised the dead `checkReportPortal()` into `isReachable(url, timeout)` and actually called it. Targets are now split into `remoteReporters` (probed) and `localReporters` (always on). Every decision is logged with a reason.

`isReachable` treats 4xx as reachable — something is listening, and auth is the uploader's problem — but 5xx, DNS failure, refused, TLS error and timeout all as down. It never throws: an unreachable results service must not be able to fail a test run. The probe is bounded by `AbortController` at 5s.

**`allure_send_results.sh`** — gates on `$ALLURE_SERVER` being set and answering before it curls. Also changes the "no result files" path from `exit 1` to `exit 0`: that previously failed the job for a condition the top of the same script already treats as normal.

**`test-against-pantheon.yml`** — both upload steps now run only when their target is in `ATK_REPORT_TARGET`, and the Testiny step checks for its API key, its input file, and its host before invoking the CLI.

## Zero reachable targets is a valid outcome

Stated explicitly because it is the point of the change. With every service down, the run still produces `list`, `html` and CTRF output, plus any local artefacts requested, and exits on the tests' own merits.

## Verification

Behaviour matrix, run against the real config:

| `ATK_REPORT_TARGET` | resulting reporters |
|---|---|
| `reportportal,allure,testiny` | `list, html, ctrf, allure-playwright, json` — reportportal **skipped with a reason** |
| *(empty)* | `list, html, ctrf` |
| `bogus` | `list, html, ctrf` — unknown target warned and ignored |

**Mutation-tested, so the check demonstrably can go both ways.** Repointing `rpconfig.endpoint` at a live host flips the outcome:

```
[reporting] reportportal: reachable — enabled
-> ["list","html","playwright-ctrf-json-reporter","@reportportal/agent-js-playwright"]
```

versus the real dead endpoint:

```
[reporting] reportportal: SKIPPED — https://reportportal.performantlabs.com/health unreachable
```

Allure gate, all three paths exercised:

| condition | behaviour |
|---|---|
| `ALLURE_SERVER` unset | skip, exit 0 |
| host unreachable | skip, exit 0 |
| host live | proceeds to `LOGIN` — the gate does not block a working server |

`bash -n` clean; the workflow parses with PyYAML.

## Noted, not fixed

`allure_send_results.sh:15` calls `uname -cs`. There is no `-c` option in GNU *or* uutils `uname`, so that line has always errored to stderr and written an empty `client_os_codename`. Harmless and pre-existing; out of scope here.

Refs #308


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Generalize dead `checkReportPortal` into `isReachable` with abort timeout and per‑target probes
  - Remote reporters are probed before enabling; local‑artefact ones always write

- Add reachability gate to `allure_send_results.sh`; treat “no files” as non‑fatal

- Gate workflow upload steps on target presence, key/file existence, and host reachability

- Zero reachable targets is now an explicitly valid outcome


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ATK_REPORT_TARGET"] --> B{"For each target"}
  B --> C["Remote?"]
  B --> D["Local?"]
  C -- yes --> E["Probe URL"]
  E -->|reachable| F["Enable reporter"]
  E -->|unreachable| G["Skip with reason"]
  D --> H["Enable reporter (local write)"]
  H --> I["Later: upload step\nwith own reachability gate"]
  F --> J["Test run continues"]
  G --> J
  I --> J
  J --> K["Zero reachable\nis valid outcome"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>playwright.config.js</strong><dd><code>Generalize remote reporter probing and split definitions</code>&nbsp; </dd></summary>
<hr>

playwright.config.js

<ul><li>Generalized <code>checkReportPortal</code> into <code>isReachable(url, timeout)</code> with <br><code>AbortController</code>, correct error handling<br> <li> Split targets into <code>remoteReporters</code> (probed) and <code>localReporters</code> (always <br>enabled)<br> <li> Probe remote targets before enabling; skip with reason if unreachable<br> <li> Unknown targets logged as warning</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/performantlabs.com/pull/310/files#diff-8421b2f4ad242eb670ea84ae0057d8708f0370adad5ac063da20b8abc54426da">+75/-20</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>allure_send_results.sh</strong><dd><code>Add reachability gate and fix no‑files exit code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

allure_send_results.sh

<ul><li>Added reachability gate: skip upload if <code>ALLURE_SERVER</code> unset or <br>unreachable<br> <li> Changed no‑result‑files exit from 1 to 0 to avoid false build failure<br> <li> Pre‑existing <code>uname -cs</code> bug untouched</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/performantlabs.com/pull/310/files#diff-6b6df20e4302a53a5b79e3820a3d6933271a54e833506355505928e35a60e0e6">+24/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test-against-pantheon.yml</strong><dd><code>Gate upload steps on target presence and service health</code>&nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/test-against-pantheon.yml

<ul><li>Condition Allure upload step on <code>allure</code> in <code>ATK_REPORT_TARGET</code><br> <li> Added Testiny upload gate: check API key, result file, and host <br>reachability before CLI<br> <li> Both steps fail gracefully (exit 0) when preconditions not met</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/performantlabs.com/pull/310/files#diff-bb1cebbf32586fd54f094aea91d88c5491491def4f5665ae7cf1dcef616b62e0">+22/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


