### PR TITLE
fix(reporting): probe once in the main process, not in every worker

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -68,6 +68,17 @@ const localReporters = {
   testiny: ['json', { outputFile: 'playwright-report.json' }],
 }
 
+/**
+ * True when this module is being imported by a Playwright WORKER rather than
+ * the main runner. Set in node_modules/playwright/lib/worker/workerProcessEntry.js.
+ *
+ * Playwright re-imports this config in every worker process, but reporters are
+ * only ever instantiated in the main process. Probing from a worker therefore
+ * achieves nothing except one redundant DNS lookup and one duplicate log line
+ * per worker, per suite — which is exactly what the first version of this did.
+ */
+const isWorker = process.env.TEST_WORKER_INDEX !== undefined
+
 // Base reporters: always on, never network-dependent.
 const reporter = [['list']]
 const isShard = process.argv.find((arg) => arg.startsWith('--shard'))
@@ -92,6 +103,9 @@ if (isShard) {
 
   for (const target of requested) {
     if (target in remoteReporters) {
+      // Main process only: see isWorker above. Nothing to decide in a worker,
+      // because the worker never builds a reporter from this array.
+      if (isWorker) continue
       const { probeUrl, reporter: rep } = remoteReporters[target]
       const url = probeUrl()
       if (await isReachable(url)) {
@@ -102,8 +116,10 @@ if (isShard) {
       }
     } else if (target in localReporters) {
       reporter.push(localReporters[target])
-      console.log(`[reporting] ${target}: enabled (writes locally; upload is a later step)`)
-    } else {
+      if (!isWorker) {
+        console.log(`[reporting] ${target}: enabled (writes locally; upload is a later step)`)
+      }
+    } else if (!isWorker) {
       console.warn(`[reporting] unknown target "${target}" — ignored`)
     }
   }


### PR DESCRIPTION
<!-- argos-status:start -->
> 🟢 **PR-Agent Score: 100** `score-90+` · model: `deepseek-v4-pro`
> 🔒 **Security:** none ✅ · ⚡ **Major:** none ✅ · 🔍 **Minor:** none ✅
> **Triggered by** `pull_request.opened` · [commit 98e1624](https://github.com/Performant-Labs/performantlabs.com/commit/98e162488886a042a7da986e86ca941a5dda8c94) · run [#30964494629](https://github.com/Performant-Labs/performantlabs.com/actions/runs/30964494629) · 2026-08-04 18:50 MDT / 2026-08-05 00:50 UTC
<!-- argos-status:end -->

### **User description**
Follow-up to #310, fixing a wart in it that the verification run exposed.

## The problem

#310's reachability probe ran **once per Playwright worker**. In the run that verified it, `[reporting] reportportal: SKIPPED …` printed more than twenty times, and each one was a real DNS lookup against a host that does not resolve.

Functionally harmless, genuinely ugly, and wasteful.

## Cause

Playwright re-imports `playwright.config.js` in every worker process — `node_modules/playwright/lib/worker/workerProcessEntry.js` sets `TEST_WORKER_INDEX` and `TEST_PARALLEL_INDEX` as it does so. But **reporters are only ever instantiated in the main process**. A worker builds the `reporter` array and never uses it, so probing there decides nothing.

## Fix

One flag, used in three places:

```js
const isWorker = process.env.TEST_WORKER_INDEX !== undefined
```

Workers skip the probe entirely and emit no reporting logs. The main process is unchanged.

## Verified

Reporter array is **identical** either way, so this is a pure noise/latency change with no behavioural difference:

| context | log output | resulting reporters |
|---|---|---|
| main process | 3 lines, as before | `list, html, ctrf, allure-playwright, json` |
| `TEST_WORKER_INDEX=0` | *(silent)* | `list, html, ctrf, allure-playwright, json` |

And the probe is genuinely skipped, not merely quiet — timed over repeated runs:

| context | config load |
|---|---|
| main process (probes) | 0.35 s, 0.36 s |
| worker (no probe) | 0.24 s, 0.24 s |

The ~110 ms difference is the DNS round trip, saved once per worker per suite.

Refs #308, #310


___

### **PR Type**
Bug fix


___

### **Description**
- Stop redundant DNS lookups and log noise from worker processes.

- Skip remote reporter probes when `TEST_WORKER_INDEX` is defined.

- Suppress console output for local reporters and unknown targets in workers.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["Playwright config loaded"] -- "Check TEST_WORKER_INDEX" --> B{isWorker?}
    B -- "Yes" --> C["Skip probes and logging"]
    B -- "No" --> D["Probe remote targets and log status"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>playwright.config.js</strong><dd><code>Guard reporter probing and logging for worker processes</code>&nbsp; &nbsp; </dd></summary>
<hr>

playwright.config.js

<ul><li>Added <code>isWorker</code> flag based on <code>TEST_WORKER_INDEX</code> environment variable.<br> <li> Wrapped reachability probe and logging for remote reporters in <code>if </code><br><code>(!isWorker)</code>.<br> <li> Suppressed console output for local reporters and unknown targets when <br>in a worker.</ul>


</details>


  </td>
  <td><a href="https://github.com/Performant-Labs/performantlabs.com/pull/311/files#diff-8421b2f4ad242eb670ea84ae0057d8708f0370adad5ac063da20b8abc54426da">+18/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___


